### PR TITLE
implement fixed chunker

### DIFF
--- a/chunkers/fixed/fastcdc_test.go
+++ b/chunkers/fixed/fastcdc_test.go
@@ -37,6 +37,8 @@ func TestFixedValidate(t *testing.T) {
 		{
 			name: "valid 64B",
 			opts: &chunkers.ChunkerOpts{
+				MinSize:    64,
+				MaxSize:    64,
 				NormalSize: 64,
 			},
 			wantErr: nil,
@@ -44,6 +46,8 @@ func TestFixedValidate(t *testing.T) {
 		{
 			name: "valid 64KB",
 			opts: &chunkers.ChunkerOpts{
+				MinSize:    64 * 1024,
+				MaxSize:    64 * 1024,
 				NormalSize: 64 * 1024,
 			},
 			wantErr: nil,
@@ -51,6 +55,8 @@ func TestFixedValidate(t *testing.T) {
 		{
 			name: "valid 1GB",
 			opts: &chunkers.ChunkerOpts{
+				MinSize:    1024 * 1024 * 1024,
+				MaxSize:    1024 * 1024 * 1024,
 				NormalSize: 1024 * 1024 * 1024,
 			},
 			wantErr: nil,
@@ -83,6 +89,31 @@ func TestFixedValidate(t *testing.T) {
 			},
 			wantErr: ErrNotPowerOfTwo,
 		},
+		{
+			name: "MinSize differing from NormalSize is rejected",
+			opts: &chunkers.ChunkerOpts{
+				MinSize:    32 * 1024,
+				MaxSize:    64 * 1024,
+				NormalSize: 64 * 1024,
+			},
+			wantErr: ErrFixedSize,
+		},
+		{
+			name: "MaxSize differing from NormalSize is rejected",
+			opts: &chunkers.ChunkerOpts{
+				MinSize:    64 * 1024,
+				MaxSize:    128 * 1024,
+				NormalSize: 64 * 1024,
+			},
+			wantErr: ErrFixedSize,
+		},
+		{
+			name: "unset Min/Max is rejected (Setup is what populates them)",
+			opts: &chunkers.ChunkerOpts{
+				NormalSize: 64 * 1024,
+			},
+			wantErr: ErrFixedSize,
+		},
 	}
 
 	for _, tt := range tests {
@@ -100,8 +131,6 @@ func TestFixedSetup(t *testing.T) {
 
 	t.Run("default setup", func(t *testing.T) {
 		opts := &chunkers.ChunkerOpts{
-			MinSize:    0,
-			MaxSize:    0,
 			NormalSize: 0,
 		}
 
@@ -110,21 +139,20 @@ func TestFixedSetup(t *testing.T) {
 			t.Fatalf("Setup() error = %v", err)
 		}
 
-		if opts.MinSize != 64*1024 {
-			t.Errorf("Expected MinSize to default to 64KB, got %d", opts.MinSize)
-		}
-		if opts.MaxSize != 64*1024 {
-			t.Errorf("Expected MaxSize to default to 64KB, got %d", opts.MaxSize)
-		}
 		if opts.NormalSize != 64*1024 {
 			t.Errorf("Expected NormalSize to default to 64KB, got %d", opts.NormalSize)
+		}
+		// Setup mirrors the single size onto Min/Max for the framework.
+		if opts.MinSize != 64*1024 {
+			t.Errorf("Expected MinSize to be mirrored to 64KB, got %d", opts.MinSize)
+		}
+		if opts.MaxSize != 64*1024 {
+			t.Errorf("Expected MaxSize to be mirrored to 64KB, got %d", opts.MaxSize)
 		}
 	})
 
 	t.Run("custom valid setup", func(t *testing.T) {
 		opts := &chunkers.ChunkerOpts{
-			MinSize:    128 * 1024,
-			MaxSize:    128 * 1024,
 			NormalSize: 128 * 1024,
 		}
 
@@ -133,8 +161,8 @@ func TestFixedSetup(t *testing.T) {
 			t.Fatalf("Setup() error = %v", err)
 		}
 
-		if opts.MinSize != 128*1024 || opts.MaxSize != 128*1024 || opts.NormalSize != 128*1024 {
-			t.Errorf("Setup() unexpectedly changed options: %+v", opts)
+		if opts.NormalSize != 128*1024 || opts.MinSize != 128*1024 || opts.MaxSize != 128*1024 {
+			t.Errorf("Setup() did not mirror NormalSize onto Min/Max: %+v", opts)
 		}
 	})
 
@@ -155,8 +183,6 @@ func TestFixedAlgorithm(t *testing.T) {
 
 	t.Run("returns n when n smaller than chunk size", func(t *testing.T) {
 		opts := &chunkers.ChunkerOpts{
-			MinSize:    64 * 1024,
-			MaxSize:    64 * 1024,
 			NormalSize: 64 * 1024,
 		}
 
@@ -169,8 +195,6 @@ func TestFixedAlgorithm(t *testing.T) {
 
 	t.Run("returns chunk size when n larger than chunk size", func(t *testing.T) {
 		opts := &chunkers.ChunkerOpts{
-			MinSize:    64 * 1024,
-			MaxSize:    64 * 1024,
 			NormalSize: 64 * 1024,
 		}
 
@@ -181,45 +205,15 @@ func TestFixedAlgorithm(t *testing.T) {
 		}
 	})
 
-	t.Run("uses MinSize if NormalSize is smaller", func(t *testing.T) {
+	t.Run("returns chunk size when n equals chunk size", func(t *testing.T) {
 		opts := &chunkers.ChunkerOpts{
-			MinSize:    128 * 1024,
-			MaxSize:    256 * 1024,
 			NormalSize: 64 * 1024,
 		}
 
-		data := make([]byte, 512*1024)
+		data := make([]byte, 64*1024)
 		cutpoint := fixed.Algorithm(opts, data, len(data))
-		if cutpoint != 128*1024 {
-			t.Errorf("Expected cutpoint 128KB, got %d", cutpoint)
-		}
-	})
-
-	t.Run("uses MaxSize if NormalSize is larger", func(t *testing.T) {
-		opts := &chunkers.ChunkerOpts{
-			MinSize:    64 * 1024,
-			MaxSize:    128 * 1024,
-			NormalSize: 256 * 1024,
-		}
-
-		data := make([]byte, 512*1024)
-		cutpoint := fixed.Algorithm(opts, data, len(data))
-		if cutpoint != 128*1024 {
-			t.Errorf("Expected cutpoint 128KB, got %d", cutpoint)
-		}
-	})
-
-	t.Run("returns n when n is smaller than effective size", func(t *testing.T) {
-		opts := &chunkers.ChunkerOpts{
-			MinSize:    128 * 1024,
-			MaxSize:    256 * 1024,
-			NormalSize: 64 * 1024, // effective size becomes 128KB
-		}
-
-		data := make([]byte, 96*1024)
-		cutpoint := fixed.Algorithm(opts, data, len(data))
-		if cutpoint != len(data) {
-			t.Errorf("Expected cutpoint %d, got %d", len(data), cutpoint)
+		if cutpoint != 64*1024 {
+			t.Errorf("Expected cutpoint 64KB, got %d", cutpoint)
 		}
 	})
 }
@@ -231,8 +225,6 @@ func TestFixedChunking(t *testing.T) {
 	}
 
 	opts := &chunkers.ChunkerOpts{
-		MinSize:    64 * 1024,
-		MaxSize:    64 * 1024,
 		NormalSize: 64 * 1024,
 	}
 
@@ -461,8 +453,6 @@ func TestFixedConsistency(t *testing.T) {
 func BenchmarkFixedAlgorithm(b *testing.B) {
 	fixed := newFixed()
 	opts := &chunkers.ChunkerOpts{
-		MinSize:    64 * 1024,
-		MaxSize:    64 * 1024,
 		NormalSize: 64 * 1024,
 	}
 
@@ -479,14 +469,12 @@ func BenchmarkFixedAlgorithm(b *testing.B) {
 
 func BenchmarkFixedSetup(b *testing.B) {
 	fixed := newFixed()
-	opts := &chunkers.ChunkerOpts{
-		MinSize:    64 * 1024,
-		MaxSize:    64 * 1024,
-		NormalSize: 64 * 1024,
-	}
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
+		opts := &chunkers.ChunkerOpts{
+			NormalSize: 64 * 1024,
+		}
 		err := fixed.Setup(opts)
 		if err != nil {
 			b.Fatalf("Setup() error = %v", err)

--- a/chunkers/fixed/fastcdc_test.go
+++ b/chunkers/fixed/fastcdc_test.go
@@ -1,0 +1,495 @@
+package fixed
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	chunkers "github.com/PlakarKorp/go-cdc-chunkers"
+)
+
+func TestFixedDefaultOptions(t *testing.T) {
+	fixed := newFixed()
+	opts := fixed.DefaultOptions()
+
+	if opts.MinSize != 64*1024 {
+		t.Errorf("Expected MinSize to be 64KB, got %d", opts.MinSize)
+	}
+	if opts.MaxSize != 64*1024 {
+		t.Errorf("Expected MaxSize to be 64KB, got %d", opts.MaxSize)
+	}
+	if opts.NormalSize != 64*1024 {
+		t.Errorf("Expected NormalSize to be 64KB, got %d", opts.NormalSize)
+	}
+	if opts.Key != nil {
+		t.Errorf("Expected Key to be nil, got %v", opts.Key)
+	}
+}
+
+func TestFixedValidate(t *testing.T) {
+	fixed := newFixed()
+
+	tests := []struct {
+		name    string
+		opts    *chunkers.ChunkerOpts
+		wantErr error
+	}{
+		{
+			name: "valid 64B",
+			opts: &chunkers.ChunkerOpts{
+				NormalSize: 64,
+			},
+			wantErr: nil,
+		},
+		{
+			name: "valid 64KB",
+			opts: &chunkers.ChunkerOpts{
+				NormalSize: 64 * 1024,
+			},
+			wantErr: nil,
+		},
+		{
+			name: "valid 1GB",
+			opts: &chunkers.ChunkerOpts{
+				NormalSize: 1024 * 1024 * 1024,
+			},
+			wantErr: nil,
+		},
+		{
+			name: "zero NormalSize",
+			opts: &chunkers.ChunkerOpts{
+				NormalSize: 0,
+			},
+			wantErr: ErrChunkSize,
+		},
+		{
+			name: "NormalSize too small",
+			opts: &chunkers.ChunkerOpts{
+				NormalSize: 32,
+			},
+			wantErr: ErrChunkSize,
+		},
+		{
+			name: "NormalSize too large",
+			opts: &chunkers.ChunkerOpts{
+				NormalSize: 1024*1024*1024 + 1,
+			},
+			wantErr: ErrChunkSize,
+		},
+		{
+			name: "NormalSize not power of two",
+			opts: &chunkers.ChunkerOpts{
+				NormalSize: 96 * 1024,
+			},
+			wantErr: ErrNotPowerOfTwo,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := fixed.Validate(tt.opts)
+			if err != tt.wantErr {
+				t.Errorf("Validate() error = %#v, wantErr %#v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestFixedSetup(t *testing.T) {
+	fixed := newFixed()
+
+	t.Run("default setup", func(t *testing.T) {
+		opts := &chunkers.ChunkerOpts{
+			MinSize:    0,
+			MaxSize:    0,
+			NormalSize: 0,
+		}
+
+		err := fixed.Setup(opts)
+		if err != nil {
+			t.Fatalf("Setup() error = %v", err)
+		}
+
+		if opts.MinSize != 64*1024 {
+			t.Errorf("Expected MinSize to default to 64KB, got %d", opts.MinSize)
+		}
+		if opts.MaxSize != 64*1024 {
+			t.Errorf("Expected MaxSize to default to 64KB, got %d", opts.MaxSize)
+		}
+		if opts.NormalSize != 64*1024 {
+			t.Errorf("Expected NormalSize to default to 64KB, got %d", opts.NormalSize)
+		}
+	})
+
+	t.Run("custom valid setup", func(t *testing.T) {
+		opts := &chunkers.ChunkerOpts{
+			MinSize:    128 * 1024,
+			MaxSize:    128 * 1024,
+			NormalSize: 128 * 1024,
+		}
+
+		err := fixed.Setup(opts)
+		if err != nil {
+			t.Fatalf("Setup() error = %v", err)
+		}
+
+		if opts.MinSize != 128*1024 || opts.MaxSize != 128*1024 || opts.NormalSize != 128*1024 {
+			t.Errorf("Setup() unexpectedly changed options: %+v", opts)
+		}
+	})
+
+	t.Run("invalid setup propagates validation error", func(t *testing.T) {
+		opts := &chunkers.ChunkerOpts{
+			NormalSize: 1000,
+		}
+
+		err := fixed.Setup(opts)
+		if err != ErrNotPowerOfTwo {
+			t.Fatalf("Setup() error = %v, want %v", err, ErrNotPowerOfTwo)
+		}
+	})
+}
+
+func TestFixedAlgorithm(t *testing.T) {
+	fixed := newFixed()
+
+	t.Run("returns n when n smaller than chunk size", func(t *testing.T) {
+		opts := &chunkers.ChunkerOpts{
+			MinSize:    64 * 1024,
+			MaxSize:    64 * 1024,
+			NormalSize: 64 * 1024,
+		}
+
+		data := make([]byte, 32*1024)
+		cutpoint := fixed.Algorithm(opts, data, len(data))
+		if cutpoint != len(data) {
+			t.Errorf("Expected cutpoint %d, got %d", len(data), cutpoint)
+		}
+	})
+
+	t.Run("returns chunk size when n larger than chunk size", func(t *testing.T) {
+		opts := &chunkers.ChunkerOpts{
+			MinSize:    64 * 1024,
+			MaxSize:    64 * 1024,
+			NormalSize: 64 * 1024,
+		}
+
+		data := make([]byte, 128*1024)
+		cutpoint := fixed.Algorithm(opts, data, len(data))
+		if cutpoint != 64*1024 {
+			t.Errorf("Expected cutpoint 64KB, got %d", cutpoint)
+		}
+	})
+
+	t.Run("uses MinSize if NormalSize is smaller", func(t *testing.T) {
+		opts := &chunkers.ChunkerOpts{
+			MinSize:    128 * 1024,
+			MaxSize:    256 * 1024,
+			NormalSize: 64 * 1024,
+		}
+
+		data := make([]byte, 512*1024)
+		cutpoint := fixed.Algorithm(opts, data, len(data))
+		if cutpoint != 128*1024 {
+			t.Errorf("Expected cutpoint 128KB, got %d", cutpoint)
+		}
+	})
+
+	t.Run("uses MaxSize if NormalSize is larger", func(t *testing.T) {
+		opts := &chunkers.ChunkerOpts{
+			MinSize:    64 * 1024,
+			MaxSize:    128 * 1024,
+			NormalSize: 256 * 1024,
+		}
+
+		data := make([]byte, 512*1024)
+		cutpoint := fixed.Algorithm(opts, data, len(data))
+		if cutpoint != 128*1024 {
+			t.Errorf("Expected cutpoint 128KB, got %d", cutpoint)
+		}
+	})
+
+	t.Run("returns n when n is smaller than effective size", func(t *testing.T) {
+		opts := &chunkers.ChunkerOpts{
+			MinSize:    128 * 1024,
+			MaxSize:    256 * 1024,
+			NormalSize: 64 * 1024, // effective size becomes 128KB
+		}
+
+		data := make([]byte, 96*1024)
+		cutpoint := fixed.Algorithm(opts, data, len(data))
+		if cutpoint != len(data) {
+			t.Errorf("Expected cutpoint %d, got %d", len(data), cutpoint)
+		}
+	})
+}
+
+func TestFixedChunking(t *testing.T) {
+	data := make([]byte, 200*1024)
+	for i := range data {
+		data[i] = byte(i % 256)
+	}
+
+	opts := &chunkers.ChunkerOpts{
+		MinSize:    64 * 1024,
+		MaxSize:    64 * 1024,
+		NormalSize: 64 * 1024,
+	}
+
+	reader := bytes.NewReader(data)
+	chunker, err := chunkers.NewChunker("fixed-v1.0.0", reader, opts)
+	if err != nil {
+		t.Fatalf("Failed to create chunker: %v", err)
+	}
+
+	if chunker.MinSize() != 64*1024 {
+		t.Errorf("Expected MinSize 64KB, got %d", chunker.MinSize())
+	}
+	if chunker.MaxSize() != 64*1024 {
+		t.Errorf("Expected MaxSize 64KB, got %d", chunker.MaxSize())
+	}
+	if chunker.NormalSize() != 64*1024 {
+		t.Errorf("Expected NormalSize 64KB, got %d", chunker.NormalSize())
+	}
+
+	var chunks [][]byte
+	for {
+		chunk, err := chunker.Next()
+		if err != nil {
+			if err == io.EOF {
+				if len(chunk) > 0 {
+					chunks = append(chunks, chunk)
+				}
+				break
+			}
+			t.Fatalf("Next() error: %v", err)
+		}
+		chunks = append(chunks, chunk)
+	}
+
+	if len(chunks) == 0 {
+		t.Fatal("No chunks were generated")
+	}
+
+	for i, chunk := range chunks {
+		if i != len(chunks)-1 && len(chunk) != 64*1024 {
+			t.Errorf("Chunk %d size %d, expected exactly 64KB", i, len(chunk))
+		}
+		if i == len(chunks)-1 && len(chunk) > 64*1024 {
+			t.Errorf("Last chunk size %d should not exceed 64KB", len(chunk))
+		}
+	}
+
+	var reconstructed []byte
+	for _, chunk := range chunks {
+		reconstructed = append(reconstructed, chunk...)
+	}
+
+	if !bytes.Equal(data, reconstructed) {
+		t.Fatal("Reconstructed data doesn't match original")
+	}
+}
+
+func TestFixedChunkingWithDefaultOptions(t *testing.T) {
+	data := make([]byte, 150*1024)
+	for i := range data {
+		data[i] = byte(i % 256)
+	}
+
+	reader := bytes.NewReader(data)
+	chunker, err := chunkers.NewChunker("fixed-v1.0.0", reader, nil)
+	if err != nil {
+		t.Fatalf("Failed to create chunker: %v", err)
+	}
+
+	var chunks [][]byte
+	for {
+		chunk, err := chunker.Next()
+		if err != nil {
+			if err == io.EOF {
+				if len(chunk) > 0 {
+					chunks = append(chunks, chunk)
+				}
+				break
+			}
+			t.Fatalf("Next() error: %v", err)
+		}
+		chunks = append(chunks, chunk)
+	}
+
+	if len(chunks) == 0 {
+		t.Fatal("No chunks were generated")
+	}
+
+	for i, chunk := range chunks {
+		if i != len(chunks)-1 && len(chunk) != 64*1024 {
+			t.Errorf("Chunk %d size %d, expected exactly 64KB", i, len(chunk))
+		}
+	}
+}
+
+func TestFixedCopy(t *testing.T) {
+	data := make([]byte, 150*1024)
+	for i := range data {
+		data[i] = byte(i % 256)
+	}
+
+	reader := bytes.NewReader(data)
+	chunker, err := chunkers.NewChunker("fixed-v1.0.0", reader, nil)
+	if err != nil {
+		t.Fatalf("Failed to create chunker: %v", err)
+	}
+
+	var buf bytes.Buffer
+	written, err := chunker.Copy(&buf)
+	if err != nil && err != io.EOF {
+		t.Fatalf("Copy() error: %v", err)
+	}
+
+	if written != int64(len(data)) {
+		t.Errorf("Copy() wrote %d bytes, expected %d", written, len(data))
+	}
+
+	if !bytes.Equal(data, buf.Bytes()) {
+		t.Fatal("Copied data doesn't match original")
+	}
+}
+
+func TestFixedSplit(t *testing.T) {
+	data := make([]byte, 150*1024)
+	for i := range data {
+		data[i] = byte(i % 256)
+	}
+
+	reader := bytes.NewReader(data)
+	chunker, err := chunkers.NewChunker("fixed-v1.0.0", reader, nil)
+	if err != nil {
+		t.Fatalf("Failed to create chunker: %v", err)
+	}
+
+	var chunks [][]byte
+	var offsets []uint
+	err = chunker.Split(func(offset, length uint, chunk []byte) error {
+		chunks = append(chunks, append([]byte{}, chunk...))
+		offsets = append(offsets, offset)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Split() error: %v", err)
+	}
+
+	if len(chunks) == 0 {
+		t.Fatal("No chunks were generated")
+	}
+
+	var reconstructed []byte
+	for _, chunk := range chunks {
+		reconstructed = append(reconstructed, chunk...)
+	}
+
+	if !bytes.Equal(data, reconstructed) {
+		t.Fatal("Reconstructed data doesn't match original")
+	}
+
+	for i := 1; i < len(offsets); i++ {
+		expectedOffset := offsets[i-1] + uint(len(chunks[i-1]))
+		if offsets[i] != expectedOffset {
+			t.Errorf("Offset %d should be %d, got %d", i, expectedOffset, offsets[i])
+		}
+	}
+}
+
+func TestFixedConsistency(t *testing.T) {
+	data := make([]byte, 150*1024)
+	for i := range data {
+		data[i] = byte(i % 256)
+	}
+
+	reader1 := bytes.NewReader(data)
+	chunker1, err := chunkers.NewChunker("fixed-v1.0.0", reader1, nil)
+	if err != nil {
+		t.Fatalf("Failed to create first chunker: %v", err)
+	}
+
+	var chunks1 [][]byte
+	for {
+		chunk, err := chunker1.Next()
+		if err != nil {
+			if err == io.EOF {
+				if len(chunk) > 0 {
+					chunks1 = append(chunks1, chunk)
+				}
+				break
+			}
+			t.Fatalf("First chunker Next() error: %v", err)
+		}
+		chunks1 = append(chunks1, chunk)
+	}
+
+	reader2 := bytes.NewReader(data)
+	chunker2, err := chunkers.NewChunker("fixed-v1.0.0", reader2, nil)
+	if err != nil {
+		t.Fatalf("Failed to create second chunker: %v", err)
+	}
+
+	var chunks2 [][]byte
+	for {
+		chunk, err := chunker2.Next()
+		if err != nil {
+			if err == io.EOF {
+				if len(chunk) > 0 {
+					chunks2 = append(chunks2, chunk)
+				}
+				break
+			}
+			t.Fatalf("Second chunker Next() error: %v", err)
+		}
+		chunks2 = append(chunks2, chunk)
+	}
+
+	if len(chunks1) != len(chunks2) {
+		t.Fatalf("Different number of chunks: %d vs %d", len(chunks1), len(chunks2))
+	}
+
+	for i := range chunks1 {
+		if !bytes.Equal(chunks1[i], chunks2[i]) {
+			t.Fatalf("Chunk %d differs between runs", i)
+		}
+	}
+}
+
+func BenchmarkFixedAlgorithm(b *testing.B) {
+	fixed := newFixed()
+	opts := &chunkers.ChunkerOpts{
+		MinSize:    64 * 1024,
+		MaxSize:    64 * 1024,
+		NormalSize: 64 * 1024,
+	}
+
+	data := make([]byte, 64*1024)
+	for i := range data {
+		data[i] = byte(i % 256)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		fixed.Algorithm(opts, data, len(data))
+	}
+}
+
+func BenchmarkFixedSetup(b *testing.B) {
+	fixed := newFixed()
+	opts := &chunkers.ChunkerOpts{
+		MinSize:    64 * 1024,
+		MaxSize:    64 * 1024,
+		NormalSize: 64 * 1024,
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := fixed.Setup(opts)
+		if err != nil {
+			b.Fatalf("Setup() error = %v", err)
+		}
+	}
+}

--- a/chunkers/fixed/fixed.go
+++ b/chunkers/fixed/fixed.go
@@ -32,6 +32,7 @@ var readDigest = func(r interface{ Read([]byte) (int, error) }, p []byte) (int, 
 
 var ErrNotPowerOfTwo = errors.New("ChunkSize must be a power of two")
 var ErrChunkSize = errors.New("ChunkSize is required and must be 64B <= ChunkSize <= 1GB")
+var ErrFixedSize = errors.New("a fixed chunker uses a single size: MinSize and MaxSize must equal NormalSize")
 
 type FixedChunker struct {
 }
@@ -50,44 +51,33 @@ func (c *FixedChunker) DefaultOptions() *chunkers.ChunkerOpts {
 }
 
 func (c *FixedChunker) Setup(options *chunkers.ChunkerOpts) error {
-	defaultOptions := c.DefaultOptions()
-	if options.MinSize == 0 {
-		options.MinSize = defaultOptions.MinSize
-	}
-	if options.MaxSize == 0 {
-		options.MaxSize = defaultOptions.MaxSize
-	}
 	if options.NormalSize == 0 {
-		options.NormalSize = defaultOptions.NormalSize
+		options.NormalSize = c.DefaultOptions().NormalSize
 	}
+	// A fixed chunker has a single size; Min and Max simply track NormalSize
+	// so the caller only ever has to set one knob.
+	options.MinSize = options.NormalSize
+	options.MaxSize = options.NormalSize
 
-	if err := c.Validate(options); err != nil {
-		return err
-	}
-	return nil
+	return c.Validate(options)
 }
 
 func (c *FixedChunker) Validate(options *chunkers.ChunkerOpts) error {
-	if options.NormalSize == 0 || options.NormalSize < 64 || options.NormalSize > 1024*1024*1024 {
+	if options.NormalSize < 64 || options.NormalSize > 1024*1024*1024 {
 		return ErrChunkSize
 	}
 	if (options.NormalSize & (options.NormalSize - 1)) != 0 {
 		return ErrNotPowerOfTwo
 	}
+	if options.MinSize != options.NormalSize || options.MaxSize != options.NormalSize {
+		return ErrFixedSize
+	}
 	return nil
 }
 
 func (c *FixedChunker) Algorithm(options *chunkers.ChunkerOpts, data []byte, n int) int {
-	size := options.NormalSize
-
-	if size < options.MinSize {
-		size = options.MinSize
-	}
-	if size > options.MaxSize {
-		size = options.MaxSize
-	}
-	if n < size {
+	if n < options.NormalSize {
 		return n
 	}
-	return size
+	return options.NormalSize
 }

--- a/chunkers/fixed/fixed.go
+++ b/chunkers/fixed/fixed.go
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2026 Gilles Chehade <gilles@poolp.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+package fixed
+
+import (
+	"errors"
+
+	chunkers "github.com/PlakarKorp/go-cdc-chunkers"
+)
+
+func init() {
+	chunkers.Register("fixed-v1.0.0", newFixed)
+}
+
+var readDigest = func(r interface{ Read([]byte) (int, error) }, p []byte) (int, error) {
+	return r.Read(p)
+}
+
+var ErrNotPowerOfTwo = errors.New("ChunkSize must be a power of two")
+var ErrChunkSize = errors.New("ChunkSize is required and must be 64B <= ChunkSize <= 1GB")
+
+type FixedChunker struct {
+}
+
+func newFixed() chunkers.ChunkerImplementation {
+	return &FixedChunker{}
+}
+
+func (c *FixedChunker) DefaultOptions() *chunkers.ChunkerOpts {
+	return &chunkers.ChunkerOpts{
+		MinSize:    64 * 1024,
+		MaxSize:    64 * 1024,
+		NormalSize: 64 * 1024,
+		Key:        nil,
+	}
+}
+
+func (c *FixedChunker) Setup(options *chunkers.ChunkerOpts) error {
+	defaultOptions := c.DefaultOptions()
+	if options.MinSize == 0 {
+		options.MinSize = defaultOptions.MinSize
+	}
+	if options.MaxSize == 0 {
+		options.MaxSize = defaultOptions.MaxSize
+	}
+	if options.NormalSize == 0 {
+		options.NormalSize = defaultOptions.NormalSize
+	}
+
+	if err := c.Validate(options); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *FixedChunker) Validate(options *chunkers.ChunkerOpts) error {
+	if options.NormalSize == 0 || options.NormalSize < 64 || options.NormalSize > 1024*1024*1024 {
+		return ErrChunkSize
+	}
+	if (options.NormalSize & (options.NormalSize - 1)) != 0 {
+		return ErrNotPowerOfTwo
+	}
+	return nil
+}
+
+func (c *FixedChunker) Algorithm(options *chunkers.ChunkerOpts, data []byte, n int) int {
+	size := options.NormalSize
+
+	if size < options.MinSize {
+		size = options.MinSize
+	}
+	if size > options.MaxSize {
+		size = options.MaxSize
+	}
+	if n < size {
+		return n
+	}
+	return size
+}

--- a/tests/chunkers_test.go
+++ b/tests/chunkers_test.go
@@ -11,6 +11,7 @@ import (
 	chunkers "github.com/PlakarKorp/go-cdc-chunkers"
 	_ "github.com/PlakarKorp/go-cdc-chunkers/chunkers/fastcdc"
 	_ "github.com/PlakarKorp/go-cdc-chunkers/chunkers/fastcdc4stadia"
+	_ "github.com/PlakarKorp/go-cdc-chunkers/chunkers/fixed"
 	_ "github.com/PlakarKorp/go-cdc-chunkers/chunkers/jc"
 	_ "github.com/PlakarKorp/go-cdc-chunkers/chunkers/ultracdc"
 )
@@ -965,6 +966,134 @@ func Test_KeyedFastCDC_Split(t *testing.T) {
 	}
 }
 
+func Test_FixedChunker_Next(t *testing.T) {
+	r := bytes.NewReader(rb)
+
+	hasher := sha256.New()
+	hasher.Write(rb)
+	sum1 := hasher.Sum(nil)
+
+	hasher.Reset()
+
+	key := make([]byte, 32)
+	crand.Read(key)
+
+	chunker, err := chunkers.NewChunker("fixed-v1.0.0", r, &chunkers.ChunkerOpts{
+		Key: key,
+	})
+	if err != nil {
+		t.Fatalf(`chunker error: %s`, err)
+	}
+	for err := error(nil); err == nil; {
+		chunk, err := chunker.Next()
+		if err != nil && err != io.EOF {
+			t.Fatalf(`chunker error: %s`, err)
+		}
+		if len(chunk) < int(chunker.MinSize()) && err != io.EOF {
+			t.Fatalf(`chunker return a chunk below MinSize before last chunk: %s`, err)
+		}
+		if len(chunk) > int(chunker.MaxSize()) {
+			t.Fatalf(`chunker return a chunk above MaxSize`)
+		}
+		hasher.Write(chunk)
+		if err == io.EOF {
+			break
+		}
+	}
+	sum2 := hasher.Sum(nil)
+
+	if !bytes.Equal(sum1, sum2) {
+		t.Fatalf(`chunker produces incorrect output`)
+	}
+}
+
+func Test_FixedChunker_Copy(t *testing.T) {
+	r := bytes.NewReader(rb)
+
+	hasher := sha256.New()
+	hasher.Write(rb)
+	sum1 := hasher.Sum(nil)
+
+	hasher.Reset()
+
+	key := make([]byte, 32)
+	crand.Read(key)
+
+	chunker, err := chunkers.NewChunker("fixed-v1.0.0", r, &chunkers.ChunkerOpts{
+		Key: key,
+	})
+	if err != nil {
+		t.Fatalf(`chunker error: %s`, err)
+	}
+
+	saw_minsize := false
+	w := writerFunc(func(p []byte) (int, error) {
+		if len(p) < int(chunker.MinSize()) {
+			if saw_minsize != false {
+				t.Fatalf(`chunker return a chunk below MinSize before last chunk: %d < %d`, len(p), int(chunker.MinSize()))
+			} else {
+				saw_minsize = true
+			}
+		}
+		if len(p) > int(chunker.MaxSize()) {
+			t.Fatalf(`chunker return a chunk above MaxSize`)
+		}
+		hasher.Write(p)
+		return len(p), nil
+	})
+	chunker.Copy(w)
+	sum2 := hasher.Sum(nil)
+
+	if !bytes.Equal(sum1, sum2) {
+		t.Fatalf(`chunker produces incorrect output`)
+	}
+}
+
+func Test_FixedChunker_Split(t *testing.T) {
+	r := bytes.NewReader(rb)
+
+	hasher := sha256.New()
+	hasher.Write(rb)
+	sum1 := hasher.Sum(nil)
+
+	hasher.Reset()
+
+	key := make([]byte, 32)
+	crand.Read(key)
+
+	chunker, err := chunkers.NewChunker("fixed-v1.0.0", r, &chunkers.ChunkerOpts{
+		Key: key,
+	})
+	if err != nil {
+		t.Fatalf(`chunker error: %s`, err)
+	}
+
+	saw_minsize := false
+	w := func(offset, length uint, chunk []byte) error {
+		if len(chunk) < int(chunker.MinSize()) {
+			if saw_minsize != false {
+				t.Fatalf(`chunker return a chunk below MinSize before last chunk: %d < %d`, len(chunk), int(chunker.MinSize()))
+			} else {
+				saw_minsize = true
+			}
+		}
+		if len(chunk) > int(chunker.MaxSize()) {
+			t.Fatalf(`chunker return a chunk above MaxSize`)
+		}
+		hasher.Write(chunk)
+		return nil
+	}
+	err = chunker.Split(w)
+	if err != nil {
+		t.Fatalf(`chunker error: %s`, err)
+	}
+	sum2 := hasher.Sum(nil)
+
+	if !bytes.Equal(sum1, sum2) {
+		t.Fatalf(`chunker produces incorrect output`)
+	}
+}
+
 func Benchmark_PlakarKorp_LegacyFastCDC_Copy(b *testing.B) {
 	r := bytes.NewReader(rb)
 	b.SetBytes(int64(r.Len()))
@@ -1657,6 +1786,261 @@ func Benchmark_PlakarKorp_JC_Next(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		chunker, err := chunkers.NewChunker("jc-v1.0.0", r, opts)
+		if err != nil {
+			b.Fatalf(`chunker error: %s`, err)
+		}
+		for err := error(nil); err == nil; {
+			_, err = chunker.Next()
+			nchunks++
+		}
+		r.Reset(rb)
+	}
+	b.ReportMetric(float64(nchunks)/float64(b.N), "chunks")
+}
+
+func Benchmark_PlakarKorp_Fixed_64KiB_Copy(b *testing.B) {
+	r := bytes.NewReader(rb)
+	b.SetBytes(int64(r.Len()))
+	b.ResetTimer()
+	nchunks := 0
+
+	opts := &chunkers.ChunkerOpts{
+		MinSize:    minSize,
+		NormalSize: avgSize,
+		MaxSize:    maxSize,
+	}
+
+	w := writerFunc(func(p []byte) (int, error) {
+		nchunks++
+		return len(p), nil
+	})
+
+	for i := 0; i < b.N; i++ {
+		chunker, err := chunkers.NewChunker("fixed-v1.0.0", r, opts)
+		if err != nil {
+			b.Fatalf(`chunker error: %s`, err)
+		}
+		chunker.Copy(w)
+		r.Reset(rb)
+	}
+	b.ReportMetric(float64(nchunks)/float64(b.N), "chunks")
+}
+
+func Benchmark_PlakarKorp_Fixed_64KiB_Split(b *testing.B) {
+	r := bytes.NewReader(rb)
+	b.SetBytes(int64(r.Len()))
+	b.ResetTimer()
+	nchunks := 0
+
+	opts := &chunkers.ChunkerOpts{
+		MinSize:    minSize,
+		NormalSize: avgSize,
+		MaxSize:    maxSize,
+	}
+
+	w := func(offset, length uint, chunk []byte) error {
+		nchunks++
+		return nil
+	}
+
+	for i := 0; i < b.N; i++ {
+		chunker, err := chunkers.NewChunker("fixed-v1.0.0", r, opts)
+		if err != nil {
+			b.Fatalf(`chunker error: %s`, err)
+		}
+		err = chunker.Split(w)
+		if err != nil && err != io.EOF {
+			b.Fatalf(`chunker error: %s`, err)
+		}
+		r.Reset(rb)
+	}
+	b.ReportMetric(float64(nchunks)/float64(b.N), "chunks")
+}
+
+func Benchmark_PlakarKorp_Fixed_64KiB_Next(b *testing.B) {
+	r := bytes.NewReader(rb)
+	b.SetBytes(int64(r.Len()))
+	b.ResetTimer()
+	nchunks := 0
+
+	opts := &chunkers.ChunkerOpts{
+		MinSize:    minSize,
+		NormalSize: avgSize,
+		MaxSize:    maxSize,
+	}
+
+	for i := 0; i < b.N; i++ {
+		chunker, err := chunkers.NewChunker("fixed-v1.0.0", r, opts)
+		if err != nil {
+			b.Fatalf(`chunker error: %s`, err)
+		}
+		for err := error(nil); err == nil; {
+			_, err = chunker.Next()
+			nchunks++
+		}
+		r.Reset(rb)
+	}
+	b.ReportMetric(float64(nchunks)/float64(b.N), "chunks")
+}
+
+func Benchmark_PlakarKorp_Fixed_1MiB_Copy(b *testing.B) {
+	r := bytes.NewReader(rb)
+	b.SetBytes(int64(r.Len()))
+	b.ResetTimer()
+	nchunks := 0
+
+	opts := &chunkers.ChunkerOpts{
+		MinSize:    1 << 20,
+		NormalSize: 1 << 20,
+		MaxSize:    1 << 20,
+	}
+
+	w := writerFunc(func(p []byte) (int, error) {
+		nchunks++
+		return len(p), nil
+	})
+
+	for i := 0; i < b.N; i++ {
+		chunker, err := chunkers.NewChunker("fixed-v1.0.0", r, opts)
+		if err != nil {
+			b.Fatalf(`chunker error: %s`, err)
+		}
+		chunker.Copy(w)
+		r.Reset(rb)
+	}
+	b.ReportMetric(float64(nchunks)/float64(b.N), "chunks")
+}
+
+func Benchmark_PlakarKorp_Fixed_1MiB_Split(b *testing.B) {
+	r := bytes.NewReader(rb)
+	b.SetBytes(int64(r.Len()))
+	b.ResetTimer()
+	nchunks := 0
+
+	opts := &chunkers.ChunkerOpts{
+		MinSize:    1 << 20,
+		NormalSize: 1 << 20,
+		MaxSize:    1 << 20,
+	}
+
+	w := func(offset, length uint, chunk []byte) error {
+		nchunks++
+		return nil
+	}
+
+	for i := 0; i < b.N; i++ {
+		chunker, err := chunkers.NewChunker("fixed-v1.0.0", r, opts)
+		if err != nil {
+			b.Fatalf(`chunker error: %s`, err)
+		}
+		err = chunker.Split(w)
+		if err != nil && err != io.EOF {
+			b.Fatalf(`chunker error: %s`, err)
+		}
+		r.Reset(rb)
+	}
+	b.ReportMetric(float64(nchunks)/float64(b.N), "chunks")
+}
+
+func Benchmark_PlakarKorp_Fixed_1MiB_Next(b *testing.B) {
+	r := bytes.NewReader(rb)
+	b.SetBytes(int64(r.Len()))
+	b.ResetTimer()
+	nchunks := 0
+
+	opts := &chunkers.ChunkerOpts{
+		MinSize:    1 << 20,
+		NormalSize: 1 << 20,
+		MaxSize:    1 << 20,
+	}
+
+	for i := 0; i < b.N; i++ {
+		chunker, err := chunkers.NewChunker("fixed-v1.0.0", r, opts)
+		if err != nil {
+			b.Fatalf(`chunker error: %s`, err)
+		}
+		for err := error(nil); err == nil; {
+			_, err = chunker.Next()
+			nchunks++
+		}
+		r.Reset(rb)
+	}
+	b.ReportMetric(float64(nchunks)/float64(b.N), "chunks")
+}
+
+func Benchmark_PlakarKorp_Fixed_4MiB_Copy(b *testing.B) {
+	r := bytes.NewReader(rb)
+	b.SetBytes(int64(r.Len()))
+	b.ResetTimer()
+	nchunks := 0
+
+	opts := &chunkers.ChunkerOpts{
+		MinSize:    4 << 20,
+		NormalSize: 4 << 20,
+		MaxSize:    4 << 20,
+	}
+
+	w := writerFunc(func(p []byte) (int, error) {
+		nchunks++
+		return len(p), nil
+	})
+
+	for i := 0; i < b.N; i++ {
+		chunker, err := chunkers.NewChunker("fixed-v1.0.0", r, opts)
+		if err != nil {
+			b.Fatalf(`chunker error: %s`, err)
+		}
+		chunker.Copy(w)
+		r.Reset(rb)
+	}
+	b.ReportMetric(float64(nchunks)/float64(b.N), "chunks")
+}
+
+func Benchmark_PlakarKorp_Fixed_4MiB_Split(b *testing.B) {
+	r := bytes.NewReader(rb)
+	b.SetBytes(int64(r.Len()))
+	b.ResetTimer()
+	nchunks := 0
+
+	opts := &chunkers.ChunkerOpts{
+		MinSize:    4 << 20,
+		NormalSize: 4 << 20,
+		MaxSize:    4 << 20,
+	}
+
+	w := func(offset, length uint, chunk []byte) error {
+		nchunks++
+		return nil
+	}
+
+	for i := 0; i < b.N; i++ {
+		chunker, err := chunkers.NewChunker("fixed-v1.0.0", r, opts)
+		if err != nil {
+			b.Fatalf(`chunker error: %s`, err)
+		}
+		err = chunker.Split(w)
+		if err != nil && err != io.EOF {
+			b.Fatalf(`chunker error: %s`, err)
+		}
+		r.Reset(rb)
+	}
+	b.ReportMetric(float64(nchunks)/float64(b.N), "chunks")
+}
+
+func Benchmark_PlakarKorp_Fixed_4MiB_Next(b *testing.B) {
+	r := bytes.NewReader(rb)
+	b.SetBytes(int64(r.Len()))
+	b.ResetTimer()
+	nchunks := 0
+
+	opts := &chunkers.ChunkerOpts{
+		MinSize:    4 << 20,
+		NormalSize: 4 << 20,
+		MaxSize:    4 << 20,
+	}
+
+	for i := 0; i < b.N; i++ {
+		chunker, err := chunkers.NewChunker("fixed-v1.0.0", r, opts)
 		if err != nil {
 			b.Fatalf(`chunker error: %s`, err)
 		}


### PR DESCRIPTION
we need a basic fixed chunker implementation:

```
$ go test -bench=. -benchmem
goos: darwin
goarch: arm64
pkg: github.com/PlakarKorp/go-cdc-chunkers/tests
cpu: Apple M4 Pro
[...]
Benchmark_PlakarKorp_FastCDC_Copy-14                           3         476148069 ns/op        2255.06 MB/s        114876 chunks         135898 B/op          7 allocs/op
Benchmark_PlakarKorp_FastCDC_Split-14                          3         476658736 ns/op        2252.64 MB/s        114877 chunks         135888 B/op          6 allocs/op
Benchmark_PlakarKorp_FastCDC_Next-14                           3         478682736 ns/op        2243.12 MB/s        114877 chunks         135888 B/op          6 allocs/op
[...]
Benchmark_PlakarKorp_Fixed_64KiB_Copy-14                      37          32321838 ns/op        33220.32 MB/s       131072 chunks         131266 B/op          4 allocs/op
Benchmark_PlakarKorp_Fixed_64KiB_Split-14                     37          32184809 ns/op        33361.76 MB/s       131073 chunks         131265 B/op          4 allocs/op
Benchmark_PlakarKorp_Fixed_64KiB_Next-14                      36          32551186 ns/op        32986.26 MB/s       131073 chunks         131265 B/op          4 allocs/op
Benchmark_PlakarKorp_Fixed_1MiB_Copy-14                       63          18871012 ns/op        56899.01 MB/s         1024 chunks        2097345 B/op          4 allocs/op
Benchmark_PlakarKorp_Fixed_1MiB_Split-14                      62          18715532 ns/op        57371.70 MB/s         1025 chunks        2097344 B/op          4 allocs/op
Benchmark_PlakarKorp_Fixed_1MiB_Next-14                       57          18694600 ns/op        57435.93 MB/s         1025 chunks        2097344 B/op          4 allocs/op
Benchmark_PlakarKorp_Fixed_4MiB_Copy-14                       61          19364792 ns/op        55448.15 MB/s          256.0 chunks      8388801 B/op          4 allocs/op
Benchmark_PlakarKorp_Fixed_4MiB_Split-14                      63          19119190 ns/op        56160.42 MB/s          257.0 chunks      8388800 B/op          4 allocs/op
Benchmark_PlakarKorp_Fixed_4MiB_Next-14                       62          19141373 ns/op        56095.34 MB/s          257.0 chunks      8388800 B/op          4 allocs/op
PASS
ok      github.com/PlakarKorp/go-cdc-chunkers/tests     93.015s
$
```