### PR TITLE
add testing harness and tooling (no implementation changes)

### DIFF
--- a/chunkers/fastcdc/reference_test.go
+++ b/chunkers/fastcdc/reference_test.go
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2025 Gilles Chehade <gilles@poolp.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+package fastcdc
+
+import (
+	"math/rand"
+	"testing"
+
+	chunkers "github.com/PlakarKorp/go-cdc-chunkers"
+)
+
+// referenceAlgorithm is the original, pre-optimisation FastCDC inner loop, kept
+// verbatim (minus the unsafe pointer arithmetic, which read one byte past the
+// slice on the final iteration). It is the ground truth that the optimised
+// Algorithm must match cutpoint-for-cutpoint. Keeping it here lets us prove the
+// hoist+unroll is output-preserving independently of the cross-package goldens.
+func (c *FastCDC) referenceAlgorithm(options *chunkers.ChunkerOpts, data []byte, n int) int {
+	MinSize := options.MinSize
+	MaxSize := options.MaxSize
+	NormalSize := options.NormalSize
+
+	switch {
+	case n <= MinSize:
+		return n
+	case n >= MaxSize:
+		n = MaxSize
+	case n <= NormalSize:
+		NormalSize = n
+	}
+
+	fp := uint64(0)
+	i := MinSize
+	mask := c.maskS
+
+	for ; i < n; i++ {
+		if i == NormalSize {
+			mask = c.maskL
+		}
+		fp = (fp << 1) + c.G[data[i]]
+		if (fp & mask) == 0 {
+			return i
+		}
+	}
+	return i
+}
+
+// TestFastCDCOptimizedMatchesReference proves the optimised Algorithm returns
+// the identical cutpoint as the reference loop across a wide range of inputs,
+// sizes and the keyed/unkeyed gear tables.
+func TestFastCDCOptimizedMatchesReference(t *testing.T) {
+	type cfg struct {
+		min, normal, max int
+	}
+	cfgs := []cfg{
+		{64, 128, 256},
+		{2 * 1024, 8 * 1024, 64 * 1024},
+		{2*1024 + 1, 8 * 1024, 64 * 1024}, // min not 8-aligned
+		{4 * 1024, 16 * 1024, 64 * 1024},
+		{1024, 2048, 4096},
+	}
+
+	// A mix of constructors so both gear tables and the legacy/v1 mask paths
+	// are exercised.
+	makers := map[string]func() chunkers.ChunkerImplementation{
+		"v1":     newFastCDC,
+		"legacy": newLegacyFastCDC,
+	}
+
+	r := rand.New(rand.NewSource(1))
+	// Several input fillings: random, all-equal, low-entropy, sequential.
+	fillers := map[string]func(n int) []byte{
+		"random": func(n int) []byte { b := make([]byte, n); r.Read(b); return b },
+		"zeros":  func(n int) []byte { return make([]byte, n) },
+		"seq": func(n int) []byte {
+			b := make([]byte, n)
+			for i := range b {
+				b[i] = byte(i)
+			}
+			return b
+		},
+	}
+
+	for mname, mk := range makers {
+		for _, cf := range cfgs {
+			opts := &chunkers.ChunkerOpts{MinSize: cf.min, NormalSize: cf.normal, MaxSize: cf.max}
+			impl := mk().(*FastCDC)
+			if err := impl.Setup(opts); err != nil {
+				t.Fatalf(`%s setup: %s`, mname, err)
+			}
+
+			for fname, fill := range fillers {
+				// Test many lengths around the boundaries (sub-min, between
+				// min and max, past max).
+				for _, n := range []int{0, 1, cf.min - 1, cf.min, cf.min + 1, cf.normal, cf.max - 1, cf.max, cf.max + 1, cf.max * 2} {
+					if n < 0 {
+						continue
+					}
+					data := fill(n)
+					want := impl.referenceAlgorithm(opts, data, len(data))
+					got := impl.Algorithm(opts, data, len(data))
+					if want != got {
+						t.Fatalf(`%s/%s n=%d cfg=%+v: optimized=%d reference=%d`, mname, fname, n, cf, got, want)
+					}
+				}
+			}
+		}
+	}
+}

--- a/chunkers/jc/reference_test.go
+++ b/chunkers/jc/reference_test.go
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2025 Gilles Chehade <gilles@poolp.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+package jc
+
+import (
+	"math/rand"
+	"testing"
+
+	chunkers "github.com/PlakarKorp/go-cdc-chunkers"
+)
+
+// referenceAlgorithm is the original JC inner loop, kept verbatim, as the
+// ground truth the resliced Algorithm must match cutpoint-for-cutpoint.
+func (c *JC) referenceAlgorithm(options *chunkers.ChunkerOpts, data []byte, n int) int {
+	MinSize := options.MinSize
+	MaxSize := options.MaxSize
+	NormalSize := options.NormalSize
+
+	switch {
+	case n <= NormalSize:
+		return n
+	case n >= MaxSize:
+		n = MaxSize
+	}
+
+	fp := uint64(0)
+	i := MinSize
+
+	for i < n {
+		fp = (fp << 1) + c.G[data[i]]
+		if (fp & c.maskJ) == 0 {
+			if (fp & c.maskC) == 0 {
+				return i
+			}
+			fp = 0
+			i = i + c.jumpLength
+		} else {
+			i++
+		}
+	}
+	return min(i, n)
+}
+
+func TestJCOptimizedMatchesReference(t *testing.T) {
+	cfgs := []struct{ min, normal, max int }{
+		{64, 128, 256},
+		{2 * 1024, 8 * 1024, 64 * 1024},
+		{2*1024 + 1, 8 * 1024, 64 * 1024},
+		{4 * 1024, 16 * 1024, 64 * 1024},
+		{1024, 4096, 16384},
+	}
+	makers := map[string]func() chunkers.ChunkerImplementation{
+		"v1":     newJC,
+		"legacy": newLegacyJC,
+	}
+	r := rand.New(rand.NewSource(3))
+	fillers := map[string]func(n int) []byte{
+		"random": func(n int) []byte { b := make([]byte, n); r.Read(b); return b },
+		"zeros":  func(n int) []byte { return make([]byte, n) },
+		"seq": func(n int) []byte {
+			b := make([]byte, n)
+			for i := range b {
+				b[i] = byte(i)
+			}
+			return b
+		},
+	}
+
+	for mname, mk := range makers {
+		for _, cf := range cfgs {
+			opts := &chunkers.ChunkerOpts{MinSize: cf.min, NormalSize: cf.normal, MaxSize: cf.max}
+			impl := mk().(*JC)
+			if err := impl.Setup(opts); err != nil {
+				t.Fatalf(`%s setup: %s`, mname, err)
+			}
+			for fname, fill := range fillers {
+				for _, n := range []int{0, 1, cf.min - 1, cf.min, cf.min + 1, cf.normal, cf.max - 1, cf.max, cf.max + 1, cf.max * 2} {
+					if n < 0 {
+						continue
+					}
+					data := fill(n)
+					want := impl.referenceAlgorithm(opts, data, len(data))
+					got := impl.Algorithm(opts, data, len(data))
+					if want != got {
+						t.Fatalf(`%s/%s n=%d cfg=%+v: optimized=%d reference=%d`, mname, fname, n, cf, got, want)
+					}
+				}
+			}
+		}
+	}
+}

--- a/chunkers/ultracdc/reference_test.go
+++ b/chunkers/ultracdc/reference_test.go
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2025 Gilles Chehade <gilles@poolp.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+package ultracdc
+
+import (
+	"bytes"
+	"math/bits"
+	"math/rand"
+	"testing"
+
+	chunkers "github.com/PlakarKorp/go-cdc-chunkers"
+)
+
+// referenceAlgorithm is the original UltraCDC inner loop, kept verbatim (two
+// table lookups per byte, slice-window loads), as the ground truth the
+// single-lookup/resliced Algorithm must match cutpoint-for-cutpoint.
+func (c *UltraCDC) referenceAlgorithm(options *chunkers.ChunkerOpts, data []byte, n int) (cutpoint int) {
+	const (
+		maskS                     uint64 = 0x2F
+		maskL                     uint64 = 0x2C
+		lowEntropyStringThreshold int    = 64
+	)
+	minSize := options.MinSize
+	maxSize := options.MaxSize
+	normalSize := options.NormalSize
+
+	var lowEntropyCount int
+	mask := maskS
+
+	switch {
+	case n <= minSize:
+		return n
+	case n >= maxSize:
+		n = maxSize
+	case n <= normalSize:
+		normalSize = n
+	}
+
+	outBufWin := data[minSize : minSize+8]
+	dist := 0
+	for _, v := range outBufWin {
+		dist += bits.OnesCount8(v ^ 0xAA)
+	}
+
+	var inBufWin []byte
+	for i := minSize + 8; i <= n-8; i += 8 {
+		if i >= normalSize {
+			mask = maskL
+		}
+		inBufWin = data[i : i+8]
+		if bytes.Equal(inBufWin, outBufWin) {
+			lowEntropyCount++
+			if lowEntropyCount >= lowEntropyStringThreshold {
+				return i + 8
+			}
+			continue
+		}
+		lowEntropyCount = 0
+		for j := 0; j < 8; j++ {
+			if (uint64(dist) & mask) == 0 {
+				return i + j
+			}
+			outByte := data[i+j-8]
+			inByte := data[i+j]
+			update := bits.OnesCount8(inByte^0xAA) - bits.OnesCount8(outByte^0xAA)
+			dist += update
+		}
+		outBufWin = inBufWin
+	}
+	return n
+}
+
+func TestUltraCDCOptimizedMatchesReference(t *testing.T) {
+	cfgs := []struct{ min, normal, max int }{
+		{64, 128, 256},
+		{2 * 1024, 10 * 1024, 64 * 1024},
+		{2*1024 + 3, 10 * 1024, 64 * 1024}, // min not 8-aligned
+		{4 * 1024, 16 * 1024, 64 * 1024},
+		{1024, 4096, 16384},
+	}
+	impl := newUltraCDC().(*UltraCDC)
+	opts0 := impl.DefaultOptions()
+	_ = opts0
+
+	r := rand.New(rand.NewSource(5))
+	// fill produces a slice of length nn but with capacity cap, mirroring how
+	// the chunker is really used: Next always hands Algorithm a window whose
+	// backing buffer has capacity >= MaxSize, so the algorithm may reslice the
+	// window up to MaxSize even when len(data) < MaxSize. Allocating exactly nn
+	// bytes (cap == nn) would violate that contract and is not a real input.
+	fillers := map[string]func(nn, cp int) []byte{
+		"random": func(nn, cp int) []byte { b := make([]byte, nn, cp); r.Read(b); return b },
+		"zeros":  func(nn, cp int) []byte { return make([]byte, nn, cp) },
+		"seq": func(nn, cp int) []byte {
+			b := make([]byte, nn, cp)
+			for i := range b {
+				b[i] = byte(i)
+			}
+			return b
+		},
+		// low-entropy: repeating 8-byte block exercises the LEST path.
+		"block8": func(nn, cp int) []byte {
+			b := make([]byte, nn, cp)
+			blk := []byte{1, 2, 3, 4, 5, 6, 7, 8}
+			for i := range b {
+				b[i] = blk[i%8]
+			}
+			return b
+		},
+	}
+
+	for _, cf := range cfgs {
+		opts := &chunkers.ChunkerOpts{MinSize: cf.min, NormalSize: cf.normal, MaxSize: cf.max}
+		for fname, fill := range fillers {
+			for _, nn := range []int{0, 1, cf.min - 1, cf.min, cf.min + 1, cf.min + 8, cf.normal, cf.max - 1, cf.max, cf.max + 1, cf.max * 2} {
+				if nn < 0 {
+					continue
+				}
+				// Capacity at least MaxSize, as the real caller guarantees.
+				cp := nn
+				if cp < cf.max {
+					cp = cf.max
+				}
+				data := fill(nn, cp)
+				want := impl.referenceAlgorithm(opts, data, len(data))
+				got := impl.Algorithm(opts, data, len(data))
+				if want != got {
+					t.Fatalf(`%s n=%d cfg=%+v: optimized=%d reference=%d`, fname, nn, cf, got, want)
+				}
+			}
+		}
+	}
+}

--- a/cmd/cdc/analyze.go
+++ b/cmd/cdc/analyze.go
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2025 Gilles Chehade <gilles@poolp.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+package main
+
+import (
+	"flag"
+	"fmt"
+)
+
+func runAnalyze(args []string) error {
+	fs := flag.NewFlagSet("analyze", flag.ExitOnError)
+	chunker := fs.String("chunker", "fastcdc-v1.0.0", "chunking algorithm")
+	var o opts
+	o.register(fs)
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	files, err := readFiles(fs.Args())
+	if err != nil {
+		return err
+	}
+
+	res, err := measure(*chunker, files, &o)
+	if err != nil {
+		return err
+	}
+	printResult(res)
+	return nil
+}
+
+func printResult(r *result) {
+	mn, p50, avg, p95, mx, stddev := r.distribution()
+	fmt.Printf("algorithm:   %s\n", r.algorithm)
+	fmt.Printf("input:       %s in %d chunk(s)\n", humanBytes(r.totalBytes), r.chunks)
+	fmt.Printf("dedup ratio: %.4f (%s unique of %s; %.2f%% saved)\n",
+		r.dedupRatio(), humanBytes(r.uniqueBytes), humanBytes(r.totalBytes),
+		100*(1-r.dedupRatio()))
+	fmt.Printf("chunk size:  min=%d p50=%d avg=%d p95=%d max=%d stddev=%.0f\n",
+		mn, p50, avg, p95, mx, stddev)
+	fmt.Printf("throughput:  %.1f MB/s\n", r.throughputMBs())
+}

--- a/cmd/cdc/cdc_test.go
+++ b/cmd/cdc/cdc_test.go
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2025 Gilles Chehade <gilles@poolp.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+package main
+
+import (
+	"bytes"
+	"math/rand"
+	"testing"
+)
+
+// buildCorpus makes a base file plus two files that share a large common
+// region, so the dedup ratio is meaningfully below 1.
+func buildCorpus(t *testing.T) [][]byte {
+	t.Helper()
+	r := rand.New(rand.NewSource(42))
+	common := make([]byte, 512*1024)
+	r.Read(common)
+	a := append(append([]byte(nil), common...), bytesOf(r, 256*1024)...)
+	b := append(append([]byte(nil), common...), bytesOf(r, 256*1024)...)
+	return [][]byte{a, b}
+}
+
+func bytesOf(r *rand.Rand, n int) []byte {
+	b := make([]byte, n)
+	r.Read(b)
+	return b
+}
+
+func TestMeasureDedup(t *testing.T) {
+	o := &opts{min: 2 * 1024, avg: 8 * 1024, max: 64 * 1024}
+	files := buildCorpus(t)
+	res, err := measure("fastcdc-v1.0.0", files, o)
+	if err != nil {
+		t.Fatalf("measure: %v", err)
+	}
+	if res.dedupRatio() >= 1.0 || res.dedupRatio() <= 0 {
+		t.Fatalf("dedup ratio out of expected range: %f", res.dedupRatio())
+	}
+	// The 512KiB common prefix should dedup, so unique < total.
+	if res.uniqueBytes >= res.totalBytes {
+		t.Fatalf("expected dedup (unique %d < total %d)", res.uniqueBytes, res.totalBytes)
+	}
+}
+
+func TestResyncSharedMonotonic(t *testing.T) {
+	o := &opts{min: 2 * 1024, avg: 8 * 1024, max: 64 * 1024}
+	r := rand.New(rand.NewSource(99))
+	orig := make([]byte, 2*1024*1024)
+	r.Read(orig)
+
+	// A single small insertion should leave most of a good chunker's output
+	// shared. We assert v1 retains the bulk of its chunks — this is both a
+	// smoke test of resyncShared and a guard that v1's resync stays healthy.
+	edited := applyInsertions(orig, 1, 1, 1)
+	shared, no, ne, err := resyncShared("fastcdc-v1.0.0", orig, edited, o)
+	if err != nil {
+		t.Fatalf("resyncShared: %v", err)
+	}
+	if no == 0 || ne == 0 {
+		t.Fatalf("expected chunks on both sides, got o=%d e=%d", no, ne)
+	}
+	if shared < 0.80 {
+		t.Fatalf("v1 resync unexpectedly low: %.2f (a single byte edit should localise)", shared)
+	}
+}
+
+func TestApplyInsertionsGrows(t *testing.T) {
+	data := bytes.Repeat([]byte{1}, 1000)
+	out := applyInsertions(data, 5, 3, 1)
+	if len(out) != len(data)+15 {
+		t.Fatalf("expected %d bytes, got %d", len(data)+15, len(out))
+	}
+}

--- a/cmd/cdc/compare.go
+++ b/cmd/cdc/compare.go
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2025 Gilles Chehade <gilles@poolp.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+package main
+
+import (
+	"flag"
+	"fmt"
+)
+
+func runCompare(args []string) error {
+	fs := flag.NewFlagSet("compare", flag.ExitOnError)
+	a := fs.String("a", "fastcdc-v1.0.0", "baseline algorithm")
+	b := fs.String("b", "fastcdc-v2.0.0", "candidate algorithm")
+	tol := fs.Float64("tol", 0.02, "dedup-ratio regression tolerance (fraction) for exit status")
+	var o opts
+	o.register(fs)
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	files, err := readFiles(fs.Args())
+	if err != nil {
+		return err
+	}
+
+	ra, err := measure(*a, files, &o)
+	if err != nil {
+		return fmt.Errorf("%s: %w", *a, err)
+	}
+	rb, err := measure(*b, files, &o)
+	if err != nil {
+		return fmt.Errorf("%s: %w", *b, err)
+	}
+
+	printComparison(ra, rb)
+
+	// Exit non-zero if the candidate's dedup ratio is worse than the baseline
+	// by more than the tolerance — so this is usable as a CI regression gate.
+	// (A higher ratio means less dedup, i.e. a regression.)
+	if rb.dedupRatio() > ra.dedupRatio()*(1+*tol) {
+		return fmt.Errorf("dedup regression: %s ratio %.4f exceeds %s %.4f by more than %.0f%%",
+			*b, rb.dedupRatio(), *a, ra.dedupRatio(), *tol*100)
+	}
+	return nil
+}
+
+func printComparison(a, b *result) {
+	amn, ap50, aavg, ap95, amx, astd := a.distribution()
+	bmn, bp50, bavg, bp95, bmx, bstd := b.distribution()
+
+	delta := func(base, cand float64) string {
+		if base == 0 {
+			return "  n/a"
+		}
+		return fmt.Sprintf("%+.1f%%", 100*(cand-base)/base)
+	}
+
+	fmt.Printf("corpus: %s\n\n", humanBytes(a.totalBytes))
+	fmt.Printf("%-16s %18s %18s %10s\n", "metric", a.algorithm, b.algorithm, "Δ(b vs a)")
+	fmt.Printf("%-16s %18.4f %18.4f %10s\n", "dedup ratio", a.dedupRatio(), b.dedupRatio(), delta(a.dedupRatio(), b.dedupRatio()))
+	fmt.Printf("%-16s %18d %18d %10s\n", "chunks", a.chunks, b.chunks, delta(float64(a.chunks), float64(b.chunks)))
+	fmt.Printf("%-16s %18d %18d %10s\n", "avg size", aavg, bavg, delta(float64(aavg), float64(bavg)))
+	fmt.Printf("%-16s %18.0f %18.0f %10s\n", "size stddev", astd, bstd, delta(astd, bstd))
+	fmt.Printf("%-16s %18.1f %18.1f %10s\n", "throughput MB/s", a.throughputMBs(), b.throughputMBs(), delta(a.throughputMBs(), b.throughputMBs()))
+	fmt.Printf("\n  %s size: min=%d p50=%d p95=%d max=%d\n", a.algorithm, amn, ap50, ap95, amx)
+	fmt.Printf("  %s size: min=%d p50=%d p95=%d max=%d\n", b.algorithm, bmn, bp50, bp95, bmx)
+}

--- a/cmd/cdc/main.go
+++ b/cmd/cdc/main.go
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2025 Gilles Chehade <gilles@poolp.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+// Command cdc analyzes and compares content-defined chunking algorithms. It
+// depends only on the chunkers library (no plotting/heavy deps), so it can
+// ship alongside the library itself.
+//
+// Subcommands:
+//
+//	cdc analyze  -chunker NAME [opts] FILE...
+//	cdc compare  -a NAME -b NAME [opts] FILE...
+//	cdc resync   -a NAME -b NAME [opts] [-edits N] FILE
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func usage() {
+	fmt.Fprintf(os.Stderr, `cdc - analyze and compare content-defined chunkers
+
+usage:
+  cdc analyze -chunker NAME [-min N -avg N -max N] FILE...
+  cdc compare -a NAME -b NAME [-min N -avg N -max N] FILE...
+  cdc resync  -a NAME -b NAME [-min N -avg N -max N] [-edits N] [-edit-size N] FILE
+
+Common options:
+  -min  minimum chunk size in bytes (default 2048)
+  -avg  average/normal chunk size in bytes (default 8192)
+  -max  maximum chunk size in bytes (default 65536)
+`)
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		usage()
+		os.Exit(2)
+	}
+
+	var err error
+	switch os.Args[1] {
+	case "analyze":
+		err = runAnalyze(os.Args[2:])
+	case "compare":
+		err = runCompare(os.Args[2:])
+	case "resync":
+		err = runResync(os.Args[2:])
+	case "-h", "--help", "help":
+		usage()
+		return
+	default:
+		fmt.Fprintf(os.Stderr, "unknown subcommand %q\n\n", os.Args[1])
+		usage()
+		os.Exit(2)
+	}
+
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "cdc: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/cmd/cdc/resync.go
+++ b/cmd/cdc/resync.go
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2025 Gilles Chehade <gilles@poolp.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+package main
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"flag"
+	"fmt"
+	"io"
+	"math/rand"
+
+	chunkers "github.com/PlakarKorp/go-cdc-chunkers"
+)
+
+// resync measures the property that actually makes content-defined chunking
+// worth using: after a small edit, a good chunker re-synchronises so only the
+// chunks near the edit change, and the rest of the file dedups against the
+// original. We chunk the original and an edited copy, then measure how much of
+// the edited file is covered by chunks the original already had.
+//
+// This is the test that catches a weak fingerprint combiner even when the
+// average chunk size looks right: if cutpoints don't re-align after a shift,
+// the shared fraction collapses.
+func runResync(args []string) error {
+	fs := flag.NewFlagSet("resync", flag.ExitOnError)
+	a := fs.String("a", "fastcdc-v1.0.0", "baseline algorithm")
+	b := fs.String("b", "fastcdc-v2.0.0", "candidate algorithm")
+	edits := fs.Int("edits", 16, "number of random edits to apply")
+	editSize := fs.Int("edit-size", 1, "bytes inserted at each edit (insertion shifts the tail)")
+	seed := fs.Int64("seed", 1, "PRNG seed for edit positions")
+	var o opts
+	o.register(fs)
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	paths := fs.Args()
+	if len(paths) != 1 {
+		return fmt.Errorf("resync takes exactly one file")
+	}
+	files, err := readFiles(paths)
+	if err != nil {
+		return err
+	}
+	orig := files[0]
+	edited := applyInsertions(orig, *edits, *editSize, *seed)
+
+	fmt.Printf("file: %s, %d insertion(s) of %d byte(s) => edited %s\n\n",
+		humanBytes(int64(len(orig))), *edits, *editSize, humanBytes(int64(len(edited))))
+
+	fmt.Printf("%-16s %12s %12s %12s\n", "algorithm", "shared%", "chunks(o)", "chunks(e)")
+	for _, algo := range []string{*a, *b} {
+		shared, no, ne, err := resyncShared(algo, orig, edited, &o)
+		if err != nil {
+			return fmt.Errorf("%s: %w", algo, err)
+		}
+		fmt.Printf("%-16s %11.2f%% %12d %12d\n", algo, 100*shared, no, ne)
+	}
+
+	fmt.Printf("\nshared%% = fraction of the edited file's bytes carried by chunks\n")
+	fmt.Printf("identical to ones in the original (higher is better resync/dedup).\n")
+	return nil
+}
+
+// resyncShared chunks both versions and returns the fraction of the edited
+// file's bytes that live in chunks whose digest also appears in the original.
+func resyncShared(algo string, orig, edited []byte, o *opts) (shared float64, nOrig, nEdited int, err error) {
+	origSet, _, err := chunkDigests(algo, orig, o)
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	editedSet, editedBytes, err := chunkDigests(algo, edited, o)
+	if err != nil {
+		return 0, 0, 0, err
+	}
+
+	var sharedBytes int64
+	for d, ln := range editedSet {
+		if _, ok := origSet[d]; ok {
+			sharedBytes += int64(ln) // ln is the (constant) length for this digest
+		}
+	}
+	if editedBytes == 0 {
+		return 0, len(origSet), len(editedSet), nil
+	}
+	return float64(sharedBytes) / float64(editedBytes), len(origSet), len(editedSet), nil
+}
+
+// chunkDigests returns the set of distinct chunk digests (mapped to their
+// length) and the total bytes chunked. Because content-defined chunks of the
+// same digest always have the same length, storing one length per digest is
+// exact.
+func chunkDigests(algo string, data []byte, o *opts) (map[[32]byte]int, int64, error) {
+	ch, err := chunkers.NewChunker(algo, bytes.NewReader(data), o.chunkerOpts())
+	if err != nil {
+		return nil, 0, err
+	}
+	set := make(map[[32]byte]int)
+	var total int64
+	for {
+		chunk, err := ch.Next()
+		if err != nil && err != io.EOF {
+			return nil, 0, err
+		}
+		if len(chunk) != 0 {
+			total += int64(len(chunk))
+			set[sha256.Sum256(chunk)] = len(chunk)
+		}
+		if err == io.EOF {
+			break
+		}
+	}
+	return set, total, nil
+}
+
+// applyInsertions returns a copy of data with n random single-position
+// insertions of editSize bytes. Insertions (rather than overwrites) shift the
+// tail, which is the hard case for chunk re-synchronisation.
+func applyInsertions(data []byte, n, editSize int, seed int64) []byte {
+	r := rand.New(rand.NewSource(seed))
+	out := append([]byte(nil), data...)
+	for i := 0; i < n; i++ {
+		pos := 0
+		if len(out) > 0 {
+			pos = r.Intn(len(out))
+		}
+		ins := make([]byte, editSize)
+		r.Read(ins)
+		out = append(out[:pos], append(ins, out[pos:]...)...)
+	}
+	return out
+}

--- a/cmd/cdc/stats.go
+++ b/cmd/cdc/stats.go
@@ -1,0 +1,185 @@
+/*
+ * Copyright (c) 2025 Gilles Chehade <gilles@poolp.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+package main
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"flag"
+	"fmt"
+	"io"
+	"math"
+	"os"
+	"sort"
+	"time"
+
+	chunkers "github.com/PlakarKorp/go-cdc-chunkers"
+	_ "github.com/PlakarKorp/go-cdc-chunkers/chunkers/fastcdc"
+	_ "github.com/PlakarKorp/go-cdc-chunkers/chunkers/fastcdc4stadia"
+	_ "github.com/PlakarKorp/go-cdc-chunkers/chunkers/jc"
+	_ "github.com/PlakarKorp/go-cdc-chunkers/chunkers/ultracdc"
+)
+
+// opts groups the size options every subcommand shares.
+type opts struct {
+	min, avg, max int
+}
+
+func (o *opts) register(fs *flag.FlagSet) {
+	fs.IntVar(&o.min, "min", 2*1024, "minimum chunk size in bytes")
+	fs.IntVar(&o.avg, "avg", 8*1024, "average/normal chunk size in bytes")
+	fs.IntVar(&o.max, "max", 64*1024, "maximum chunk size in bytes")
+}
+
+func (o *opts) chunkerOpts() *chunkers.ChunkerOpts {
+	return &chunkers.ChunkerOpts{MinSize: o.min, NormalSize: o.avg, MaxSize: o.max}
+}
+
+// chunkStat is the per-chunk record we keep: its length and content digest.
+// The digest is what lets us count unique chunks for the dedup ratio.
+type chunkStat struct {
+	length int
+	digest [32]byte
+}
+
+// result is the full measurement of running one algorithm over one corpus.
+type result struct {
+	algorithm string
+
+	totalBytes  int64
+	chunks      int
+	uniqueBytes int64 // sum of lengths of distinct chunks (by digest)
+	uniqueChunk int
+
+	lengths  []int // every chunk length, for the distribution
+	duration time.Duration
+}
+
+// dedupRatio is uniqueBytes/totalBytes: the fraction of the corpus that must
+// actually be stored after deduplication. Lower is better.
+func (r *result) dedupRatio() float64 {
+	if r.totalBytes == 0 {
+		return 0
+	}
+	return float64(r.uniqueBytes) / float64(r.totalBytes)
+}
+
+func (r *result) throughputMBs() float64 {
+	if r.duration == 0 {
+		return 0
+	}
+	return float64(r.totalBytes) / 1e6 / r.duration.Seconds()
+}
+
+// distribution returns min/p50/avg/p95/max and the standard deviation of the
+// chunk lengths. Chunk-size variance matters: a tight distribution around the
+// target is a sign of a well-behaved chunker.
+func (r *result) distribution() (mn, p50, avg, p95, mx int, stddev float64) {
+	if len(r.lengths) == 0 {
+		return
+	}
+	sorted := append([]int(nil), r.lengths...)
+	sort.Ints(sorted)
+	mn = sorted[0]
+	mx = sorted[len(sorted)-1]
+	p50 = sorted[len(sorted)*50/100]
+	p95 = sorted[len(sorted)*95/100]
+
+	var sum int64
+	for _, l := range sorted {
+		sum += int64(l)
+	}
+	mean := float64(sum) / float64(len(sorted))
+	avg = int(mean)
+
+	var sq float64
+	for _, l := range sorted {
+		d := float64(l) - mean
+		sq += d * d
+	}
+	stddev = math.Sqrt(sq / float64(len(sorted)))
+	return
+}
+
+// measure chunks every file with the given algorithm, accumulating per-chunk
+// digests into seen so the dedup ratio is computed across the whole corpus
+// (cross-file dedup, not just within a single file). It returns the aggregate
+// result.
+func measure(algorithm string, files [][]byte, o *opts) (*result, error) {
+	res := &result{algorithm: algorithm}
+	seen := make(map[[32]byte]struct{})
+
+	for _, data := range files {
+		ch, err := chunkers.NewChunker(algorithm, bytes.NewReader(data), o.chunkerOpts())
+		if err != nil {
+			return nil, err
+		}
+		start := time.Now()
+		for {
+			chunk, err := ch.Next()
+			if err != nil && err != io.EOF {
+				return nil, err
+			}
+			if len(chunk) != 0 {
+				res.chunks++
+				res.totalBytes += int64(len(chunk))
+				res.lengths = append(res.lengths, len(chunk))
+				d := sha256.Sum256(chunk)
+				if _, ok := seen[d]; !ok {
+					seen[d] = struct{}{}
+					res.uniqueChunk++
+					res.uniqueBytes += int64(len(chunk))
+				}
+			}
+			if err == io.EOF {
+				break
+			}
+		}
+		res.duration += time.Since(start)
+	}
+	return res, nil
+}
+
+// readFiles loads every path into memory.
+func readFiles(paths []string) ([][]byte, error) {
+	if len(paths) == 0 {
+		return nil, fmt.Errorf("need at least one input file")
+	}
+	files := make([][]byte, 0, len(paths))
+	for _, p := range paths {
+		data, err := os.ReadFile(p)
+		if err != nil {
+			return nil, err
+		}
+		files = append(files, data)
+	}
+	return files, nil
+}
+
+// humanBytes formats a byte count compactly.
+func humanBytes(n int64) string {
+	const unit = 1024
+	if n < unit {
+		return fmt.Sprintf("%dB", n)
+	}
+	div, exp := int64(unit), 0
+	for x := n / unit; x >= unit; x /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f%ciB", float64(n)/float64(div), "KMGTPE"[exp])
+}

--- a/tests/golden_test.go
+++ b/tests/golden_test.go
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2025 Gilles Chehade <gilles@poolp.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+package tests
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	chunkers "github.com/PlakarKorp/go-cdc-chunkers"
+)
+
+// updateGolden, when set, rewrites the golden fingerprints from the current
+// code instead of asserting against them:
+//
+//	go test ./tests/ -run TestGolden -update
+//
+// The fingerprints are the idempotency oracle. They are produced once from the
+// reference (bufio) implementation; every later change must reproduce them
+// exactly. We do not store full per-chunk profiles (they run to megabytes for
+// small-chunk profiles over large inputs); a fingerprint over the cutpoint
+// sequence plus the global content digest is just as strict and stays tiny.
+var updateGolden = flag.Bool("update", false, "regenerate golden fingerprints")
+
+const goldenFile = "testdata/golden.json"
+
+// fingerprint is the compact, exact signature of one chunking run: the number
+// of chunks, a digest over the cutpoint-length sequence, and the digest over
+// the reconstructed content. Two runs with the same fingerprint produced the
+// same cutpoints over the same bytes.
+type fingerprint struct {
+	Chunks   int    `json:"chunks"`
+	CutsHash string `json:"cuts_hash"`
+	Content  string `json:"content"`
+}
+
+// fingerprintOf chunks data with the legacy bufio path and returns its
+// fingerprint, also asserting that the chunks reconstruct the input exactly.
+func fingerprintOf(t *testing.T, algo string, data []byte, opts *chunkers.ChunkerOpts) fingerprint {
+	t.Helper()
+	ch, err := newBufioChunker(algo, data, opts)
+	if err != nil {
+		t.Fatalf(`bufio chunker: %s`, err)
+	}
+	lengths, all, err := collectNext(ch)
+	if err != nil {
+		t.Fatalf(`bufio collect: %s`, err)
+	}
+	if !bytes.Equal(all, data) {
+		t.Fatalf(`reconstruction != input (got %d want %d)`, len(all), len(data))
+	}
+	return fingerprintFrom(lengths, all)
+}
+
+// fingerprintFrom builds a fingerprint from a cutpoint-length sequence and the
+// reconstructed content. It is the single definition of "same output" used by
+// both the golden oracle and the differential tests.
+func fingerprintFrom(lengths []int, content []byte) fingerprint {
+	h := sha256.New()
+	var buf [8]byte
+	for _, l := range lengths {
+		binary.LittleEndian.PutUint64(buf[:], uint64(l))
+		h.Write(buf[:])
+	}
+	c := sha256.Sum256(content)
+	return fingerprint{
+		Chunks:   len(lengths),
+		CutsHash: fmt.Sprintf("%x", h.Sum(nil)),
+		Content:  fmt.Sprintf("%x", c[:]),
+	}
+}
+
+func caseName(algo, size, input string) string {
+	return fmt.Sprintf("%s|%s|%s", algo, size, input)
+}
+
+func TestGolden(t *testing.T) {
+	maxMax := 0
+	for _, sp := range sizeProfiles {
+		if sp.max > maxMax {
+			maxMax = sp.max
+		}
+	}
+	inputs := makeInputs(maxMax)
+
+	got := map[string]fingerprint{}
+	for _, a := range allAlgorithms {
+		for _, sp := range sizeProfiles {
+			for _, in := range inputs {
+				name := caseName(a.name, sp.name, in.name)
+				got[name] = fingerprintOf(t, a.name, in.data, optsFor(a, sp))
+			}
+		}
+	}
+
+	if *updateGolden {
+		if err := os.MkdirAll(filepath.Dir(goldenFile), 0o755); err != nil {
+			t.Fatalf(`mkdir golden: %s`, err)
+		}
+		buf, err := json.MarshalIndent(got, "", "  ")
+		if err != nil {
+			t.Fatalf(`marshal golden: %s`, err)
+		}
+		if err := os.WriteFile(goldenFile, buf, 0o644); err != nil {
+			t.Fatalf(`write golden: %s`, err)
+		}
+		t.Logf("wrote %d golden fingerprints to %s", len(got), goldenFile)
+		return
+	}
+
+	want := loadGolden(t)
+	if len(want) != len(got) {
+		t.Fatalf(`golden case count mismatch: want %d got %d (regenerate with -update)`, len(want), len(got))
+	}
+
+	// Sort case names so failures are reported deterministically.
+	names := make([]string, 0, len(got))
+	for n := range got {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+
+	for _, n := range names {
+		w, ok := want[n]
+		if !ok {
+			t.Errorf(`%s: missing from golden (regenerate with -update)`, n)
+			continue
+		}
+		g := got[n]
+		if w != g {
+			t.Errorf(`%s: fingerprint drift\n  want %+v\n  got  %+v`, n, w, g)
+		}
+	}
+}
+
+func loadGolden(t *testing.T) map[string]fingerprint {
+	t.Helper()
+	buf, err := os.ReadFile(goldenFile)
+	if err != nil {
+		t.Fatalf(`read golden (regenerate with -update): %s`, err)
+	}
+	var m map[string]fingerprint
+	if err := json.Unmarshal(buf, &m); err != nil {
+		t.Fatalf(`unmarshal golden: %s`, err)
+	}
+	return m
+}

--- a/tests/harness_test.go
+++ b/tests/harness_test.go
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2025 Gilles Chehade <gilles@poolp.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+package tests
+
+import (
+	"bytes"
+	"io"
+	"math/rand"
+
+	chunkers "github.com/PlakarKorp/go-cdc-chunkers"
+)
+
+// This file is shared scaffolding for the equivalence, golden and fuzz tests.
+// It deliberately depends on nothing but the public API so that the very same
+// helpers exercise both the legacy bufio path and the new buffer path.
+
+// algoParams describes one registered algorithm and whether it needs a key.
+type algoParams struct {
+	name  string
+	keyed bool
+}
+
+// allAlgorithms is the full set of registered algorithms we hold to the
+// idempotency contract. kfastcdc is keyed and is fed a fixed key below.
+var allAlgorithms = []algoParams{
+	{name: "fastcdc"},
+	{name: "fastcdc-v1.0.0"},
+	{name: "kfastcdc", keyed: true},
+	{name: "jc"},
+	{name: "jc-v1.0.0"},
+	{name: "ultracdc"},
+	{name: "fastcdc4stadia"},
+}
+
+// fixedKey is a deterministic 32 byte key, so keyed runs are reproducible.
+var fixedKey = func() []byte {
+	k := make([]byte, 32)
+	for i := range k {
+		k[i] = byte(i*7 + 3)
+	}
+	return k
+}()
+
+// sizeProfile is one (min, normal, max) triple.
+type sizeProfile struct {
+	name   string
+	min    int
+	normal int
+	max    int
+}
+
+// sizeProfiles spans the default profile, a large-chunk profile, and the
+// multi-MiB MaxSize regime that the kloset workload actually uses at high
+// concurrency. Every profile keeps min < normal < max and a power-of-two
+// normal, so FastCDC's Validate accepts it.
+var sizeProfiles = []sizeProfile{
+	{name: "2K-8K-64K", min: 2 * 1024, normal: 8 * 1024, max: 64 * 1024},
+	{name: "256K-512K-1M", min: 256 * 1024, normal: 512 * 1024, max: 1024 * 1024},
+	{name: "1M-4M-16M", min: 1024 * 1024, normal: 4 * 1024 * 1024, max: 16 * 1024 * 1024},
+}
+
+// optsFor builds the ChunkerOpts for an algorithm/size combination, attaching
+// the fixed key for keyed algorithms.
+func optsFor(a algoParams, sp sizeProfile) *chunkers.ChunkerOpts {
+	opts := &chunkers.ChunkerOpts{
+		MinSize:    sp.min,
+		NormalSize: sp.normal,
+		MaxSize:    sp.max,
+	}
+	if a.keyed {
+		opts.Key = fixedKey
+	}
+	return opts
+}
+
+// inputShape describes one synthetic input and how to materialise it.
+type inputShape struct {
+	name string
+	data []byte
+}
+
+// makeInputs builds a deterministic battery of inputs sized relative to the
+// largest MaxSize in play so that every boundary (empty, sub-min, exactly
+// min/normal/max, just past max, several max) is hit. maxMax is the largest
+// MaxSize across the size profiles.
+func makeInputs(maxMax int) []inputShape {
+	rnd := func(n int) []byte {
+		b := make([]byte, n)
+		// Fixed seed: goldens must be reproducible across machines.
+		r := rand.New(rand.NewSource(0))
+		r.Read(b)
+		return b
+	}
+	zeros := func(n int) []byte { return make([]byte, n) }
+	repeat := func(n int) []byte {
+		// A short repeating pattern: highly compressible, exercises the
+		// UltraCDC low-entropy path and FastCDC's failure-to-cut behaviour.
+		b := make([]byte, n)
+		pat := []byte("plakar")
+		for i := range b {
+			b[i] = pat[i%len(pat)]
+		}
+		return b
+	}
+
+	shapes := []inputShape{
+		{name: "empty", data: []byte{}},
+		{name: "one-byte", data: []byte{0x42}},
+		{name: "tiny-64", data: rnd(64)},
+		{name: "random-3x-maxmax", data: rnd(3 * maxMax)},
+		{name: "zeros-2x-maxmax", data: zeros(2 * maxMax)},
+		{name: "repeat-2x-maxmax", data: repeat(2 * maxMax)},
+	}
+	return shapes
+}
+
+// collectNext drives a chunker through Next and returns the cutpoint lengths
+// and the concatenation of all chunks. It tolerates the io.EOF sentinel the
+// same way the package's own tests do.
+func collectNext(ch *chunkers.Chunker) (lengths []int, all []byte, err error) {
+	for {
+		chunk, e := ch.Next()
+		if e != nil && e != io.EOF {
+			return nil, nil, e
+		}
+		if len(chunk) != 0 {
+			lengths = append(lengths, len(chunk))
+			all = append(all, chunk...)
+		}
+		if e == io.EOF {
+			break
+		}
+	}
+	return lengths, all, nil
+}
+
+// newBufioChunker builds a chunker over the legacy bufio path (the behaviour
+// we are holding everything else equal to).
+func newBufioChunker(algorithm string, data []byte, opts *chunkers.ChunkerOpts) (*chunkers.Chunker, error) {
+	return chunkers.NewChunker(algorithm, bytes.NewReader(data), opts)
+}

--- a/tests/testdata/.gitattributes
+++ b/tests/testdata/.gitattributes
@@ -1,0 +1,1 @@
+golden.json -diff

--- a/tests/testdata/golden.json
+++ b/tests/testdata/golden.json
@@ -1,0 +1,632 @@
+{
+  "fastcdc-v1.0.0|1M-4M-16M|empty": {
+    "chunks": 0,
+    "cuts_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "content": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  },
+  "fastcdc-v1.0.0|1M-4M-16M|one-byte": {
+    "chunks": 1,
+    "cuts_hash": "7c9fa136d4413fa6173637e883b6998d32e1d675f88cddff9dcbcf331820f4b8",
+    "content": "df7e70e5021544f4834bbee64a9e3789febc4be81470df629cad6ddb03320a5c"
+  },
+  "fastcdc-v1.0.0|1M-4M-16M|random-3x-maxmax": {
+    "chunks": 11,
+    "cuts_hash": "205e7e572350d8b43eebc79c3cddb252bda97b84021590bee54c4e875d395a98",
+    "content": "867237994656ede84fa9878ed0d15cb4bd009a9c560f3e15524a2e779f8c03fe"
+  },
+  "fastcdc-v1.0.0|1M-4M-16M|repeat-2x-maxmax": {
+    "chunks": 2,
+    "cuts_hash": "8a2e77537c324b8ecfa4a28090b2c315d294926af6265bfacf6584bc310ea93e",
+    "content": "1fdc2b342ea4e199bc5cbdba27958680eb2103a6580a823439d90f7ea2a90dba"
+  },
+  "fastcdc-v1.0.0|1M-4M-16M|tiny-64": {
+    "chunks": 1,
+    "cuts_hash": "a06f129fc52abf6085679d7cd71dc41ec7580c7f5f73efef6d02dde22bb00994",
+    "content": "565966bd0e0cedaa92f154c2d17abfa4c5f98a668cef2e20b0855558e0583db9"
+  },
+  "fastcdc-v1.0.0|1M-4M-16M|zeros-2x-maxmax": {
+    "chunks": 2,
+    "cuts_hash": "8a2e77537c324b8ecfa4a28090b2c315d294926af6265bfacf6584bc310ea93e",
+    "content": "83ee47245398adee79bd9c0a8bc57b821e92aba10f5f9ade8a5d1fae4d8c4302"
+  },
+  "fastcdc-v1.0.0|256K-512K-1M|empty": {
+    "chunks": 0,
+    "cuts_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "content": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  },
+  "fastcdc-v1.0.0|256K-512K-1M|one-byte": {
+    "chunks": 1,
+    "cuts_hash": "7c9fa136d4413fa6173637e883b6998d32e1d675f88cddff9dcbcf331820f4b8",
+    "content": "df7e70e5021544f4834bbee64a9e3789febc4be81470df629cad6ddb03320a5c"
+  },
+  "fastcdc-v1.0.0|256K-512K-1M|random-3x-maxmax": {
+    "chunks": 83,
+    "cuts_hash": "034713ea800ffc5fc5b12ca163b69f8ebac11de230078a0ce0f35689c939ec6a",
+    "content": "867237994656ede84fa9878ed0d15cb4bd009a9c560f3e15524a2e779f8c03fe"
+  },
+  "fastcdc-v1.0.0|256K-512K-1M|repeat-2x-maxmax": {
+    "chunks": 32,
+    "cuts_hash": "6207c153ab65f7dd7da183e82ee7900c131f20f90e690d10e638d8896cee02e7",
+    "content": "1fdc2b342ea4e199bc5cbdba27958680eb2103a6580a823439d90f7ea2a90dba"
+  },
+  "fastcdc-v1.0.0|256K-512K-1M|tiny-64": {
+    "chunks": 1,
+    "cuts_hash": "a06f129fc52abf6085679d7cd71dc41ec7580c7f5f73efef6d02dde22bb00994",
+    "content": "565966bd0e0cedaa92f154c2d17abfa4c5f98a668cef2e20b0855558e0583db9"
+  },
+  "fastcdc-v1.0.0|256K-512K-1M|zeros-2x-maxmax": {
+    "chunks": 32,
+    "cuts_hash": "6207c153ab65f7dd7da183e82ee7900c131f20f90e690d10e638d8896cee02e7",
+    "content": "83ee47245398adee79bd9c0a8bc57b821e92aba10f5f9ade8a5d1fae4d8c4302"
+  },
+  "fastcdc-v1.0.0|2K-8K-64K|empty": {
+    "chunks": 0,
+    "cuts_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "content": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  },
+  "fastcdc-v1.0.0|2K-8K-64K|one-byte": {
+    "chunks": 1,
+    "cuts_hash": "7c9fa136d4413fa6173637e883b6998d32e1d675f88cddff9dcbcf331820f4b8",
+    "content": "df7e70e5021544f4834bbee64a9e3789febc4be81470df629cad6ddb03320a5c"
+  },
+  "fastcdc-v1.0.0|2K-8K-64K|random-3x-maxmax": {
+    "chunks": 5382,
+    "cuts_hash": "545d89c340c72d930b35f982bf6c955062fa243ea1957031926d5b6538539f69",
+    "content": "867237994656ede84fa9878ed0d15cb4bd009a9c560f3e15524a2e779f8c03fe"
+  },
+  "fastcdc-v1.0.0|2K-8K-64K|repeat-2x-maxmax": {
+    "chunks": 512,
+    "cuts_hash": "b985af207b5cbf7a3e6dfd235fbfff680cfac9e3f6cc399930f1e791924cd8f1",
+    "content": "1fdc2b342ea4e199bc5cbdba27958680eb2103a6580a823439d90f7ea2a90dba"
+  },
+  "fastcdc-v1.0.0|2K-8K-64K|tiny-64": {
+    "chunks": 1,
+    "cuts_hash": "a06f129fc52abf6085679d7cd71dc41ec7580c7f5f73efef6d02dde22bb00994",
+    "content": "565966bd0e0cedaa92f154c2d17abfa4c5f98a668cef2e20b0855558e0583db9"
+  },
+  "fastcdc-v1.0.0|2K-8K-64K|zeros-2x-maxmax": {
+    "chunks": 512,
+    "cuts_hash": "b985af207b5cbf7a3e6dfd235fbfff680cfac9e3f6cc399930f1e791924cd8f1",
+    "content": "83ee47245398adee79bd9c0a8bc57b821e92aba10f5f9ade8a5d1fae4d8c4302"
+  },
+  "fastcdc4stadia|1M-4M-16M|empty": {
+    "chunks": 0,
+    "cuts_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "content": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  },
+  "fastcdc4stadia|1M-4M-16M|one-byte": {
+    "chunks": 1,
+    "cuts_hash": "7c9fa136d4413fa6173637e883b6998d32e1d675f88cddff9dcbcf331820f4b8",
+    "content": "df7e70e5021544f4834bbee64a9e3789febc4be81470df629cad6ddb03320a5c"
+  },
+  "fastcdc4stadia|1M-4M-16M|random-3x-maxmax": {
+    "chunks": 13,
+    "cuts_hash": "46604c54e71ed69797beba0305c7fca90414d01f5c93b5e81f71168e9feeffc6",
+    "content": "867237994656ede84fa9878ed0d15cb4bd009a9c560f3e15524a2e779f8c03fe"
+  },
+  "fastcdc4stadia|1M-4M-16M|repeat-2x-maxmax": {
+    "chunks": 3,
+    "cuts_hash": "691f181102db85c9378827ef0eeb07764c48eb2781739c73ab6803d1f9225647",
+    "content": "1fdc2b342ea4e199bc5cbdba27958680eb2103a6580a823439d90f7ea2a90dba"
+  },
+  "fastcdc4stadia|1M-4M-16M|tiny-64": {
+    "chunks": 1,
+    "cuts_hash": "a06f129fc52abf6085679d7cd71dc41ec7580c7f5f73efef6d02dde22bb00994",
+    "content": "565966bd0e0cedaa92f154c2d17abfa4c5f98a668cef2e20b0855558e0583db9"
+  },
+  "fastcdc4stadia|1M-4M-16M|zeros-2x-maxmax": {
+    "chunks": 2,
+    "cuts_hash": "8a2e77537c324b8ecfa4a28090b2c315d294926af6265bfacf6584bc310ea93e",
+    "content": "83ee47245398adee79bd9c0a8bc57b821e92aba10f5f9ade8a5d1fae4d8c4302"
+  },
+  "fastcdc4stadia|256K-512K-1M|empty": {
+    "chunks": 0,
+    "cuts_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "content": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  },
+  "fastcdc4stadia|256K-512K-1M|one-byte": {
+    "chunks": 1,
+    "cuts_hash": "7c9fa136d4413fa6173637e883b6998d32e1d675f88cddff9dcbcf331820f4b8",
+    "content": "df7e70e5021544f4834bbee64a9e3789febc4be81470df629cad6ddb03320a5c"
+  },
+  "fastcdc4stadia|256K-512K-1M|random-3x-maxmax": {
+    "chunks": 104,
+    "cuts_hash": "36c0ab5b4175b7f618a0687e7840f165c52e964d7febb43f767ce64c4ac89ead",
+    "content": "867237994656ede84fa9878ed0d15cb4bd009a9c560f3e15524a2e779f8c03fe"
+  },
+  "fastcdc4stadia|256K-512K-1M|repeat-2x-maxmax": {
+    "chunks": 33,
+    "cuts_hash": "91398034ab4d6a6ee82c72c901f936a348470d19201c4e3c93cf3db489a92ee5",
+    "content": "1fdc2b342ea4e199bc5cbdba27958680eb2103a6580a823439d90f7ea2a90dba"
+  },
+  "fastcdc4stadia|256K-512K-1M|tiny-64": {
+    "chunks": 1,
+    "cuts_hash": "a06f129fc52abf6085679d7cd71dc41ec7580c7f5f73efef6d02dde22bb00994",
+    "content": "565966bd0e0cedaa92f154c2d17abfa4c5f98a668cef2e20b0855558e0583db9"
+  },
+  "fastcdc4stadia|256K-512K-1M|zeros-2x-maxmax": {
+    "chunks": 32,
+    "cuts_hash": "6207c153ab65f7dd7da183e82ee7900c131f20f90e690d10e638d8896cee02e7",
+    "content": "83ee47245398adee79bd9c0a8bc57b821e92aba10f5f9ade8a5d1fae4d8c4302"
+  },
+  "fastcdc4stadia|2K-8K-64K|empty": {
+    "chunks": 0,
+    "cuts_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "content": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  },
+  "fastcdc4stadia|2K-8K-64K|one-byte": {
+    "chunks": 1,
+    "cuts_hash": "7c9fa136d4413fa6173637e883b6998d32e1d675f88cddff9dcbcf331820f4b8",
+    "content": "df7e70e5021544f4834bbee64a9e3789febc4be81470df629cad6ddb03320a5c"
+  },
+  "fastcdc4stadia|2K-8K-64K|random-3x-maxmax": {
+    "chunks": 6138,
+    "cuts_hash": "c8a34efa617bd2d1c67cd1a92ff4013374dc787daede2f6ed1a6e7862ff371fd",
+    "content": "867237994656ede84fa9878ed0d15cb4bd009a9c560f3e15524a2e779f8c03fe"
+  },
+  "fastcdc4stadia|2K-8K-64K|repeat-2x-maxmax": {
+    "chunks": 513,
+    "cuts_hash": "6f2f5fa49a9f3af65063490e81f8aae0a8a78e43abb7bf622be8d9fb97f06371",
+    "content": "1fdc2b342ea4e199bc5cbdba27958680eb2103a6580a823439d90f7ea2a90dba"
+  },
+  "fastcdc4stadia|2K-8K-64K|tiny-64": {
+    "chunks": 1,
+    "cuts_hash": "a06f129fc52abf6085679d7cd71dc41ec7580c7f5f73efef6d02dde22bb00994",
+    "content": "565966bd0e0cedaa92f154c2d17abfa4c5f98a668cef2e20b0855558e0583db9"
+  },
+  "fastcdc4stadia|2K-8K-64K|zeros-2x-maxmax": {
+    "chunks": 512,
+    "cuts_hash": "b985af207b5cbf7a3e6dfd235fbfff680cfac9e3f6cc399930f1e791924cd8f1",
+    "content": "83ee47245398adee79bd9c0a8bc57b821e92aba10f5f9ade8a5d1fae4d8c4302"
+  },
+  "fastcdc|1M-4M-16M|empty": {
+    "chunks": 0,
+    "cuts_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "content": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  },
+  "fastcdc|1M-4M-16M|one-byte": {
+    "chunks": 1,
+    "cuts_hash": "7c9fa136d4413fa6173637e883b6998d32e1d675f88cddff9dcbcf331820f4b8",
+    "content": "df7e70e5021544f4834bbee64a9e3789febc4be81470df629cad6ddb03320a5c"
+  },
+  "fastcdc|1M-4M-16M|random-3x-maxmax": {
+    "chunks": 47,
+    "cuts_hash": "1afc38261446ad0cdc3fa28f1535caebd37b52db8769cd8c31ef7fc1e9b44316",
+    "content": "867237994656ede84fa9878ed0d15cb4bd009a9c560f3e15524a2e779f8c03fe"
+  },
+  "fastcdc|1M-4M-16M|repeat-2x-maxmax": {
+    "chunks": 2,
+    "cuts_hash": "8a2e77537c324b8ecfa4a28090b2c315d294926af6265bfacf6584bc310ea93e",
+    "content": "1fdc2b342ea4e199bc5cbdba27958680eb2103a6580a823439d90f7ea2a90dba"
+  },
+  "fastcdc|1M-4M-16M|tiny-64": {
+    "chunks": 1,
+    "cuts_hash": "a06f129fc52abf6085679d7cd71dc41ec7580c7f5f73efef6d02dde22bb00994",
+    "content": "565966bd0e0cedaa92f154c2d17abfa4c5f98a668cef2e20b0855558e0583db9"
+  },
+  "fastcdc|1M-4M-16M|zeros-2x-maxmax": {
+    "chunks": 2,
+    "cuts_hash": "8a2e77537c324b8ecfa4a28090b2c315d294926af6265bfacf6584bc310ea93e",
+    "content": "83ee47245398adee79bd9c0a8bc57b821e92aba10f5f9ade8a5d1fae4d8c4302"
+  },
+  "fastcdc|256K-512K-1M|empty": {
+    "chunks": 0,
+    "cuts_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "content": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  },
+  "fastcdc|256K-512K-1M|one-byte": {
+    "chunks": 1,
+    "cuts_hash": "7c9fa136d4413fa6173637e883b6998d32e1d675f88cddff9dcbcf331820f4b8",
+    "content": "df7e70e5021544f4834bbee64a9e3789febc4be81470df629cad6ddb03320a5c"
+  },
+  "fastcdc|256K-512K-1M|random-3x-maxmax": {
+    "chunks": 174,
+    "cuts_hash": "e28d2268f839707ea5b79c5e4f2350e871ed3b857b0ecd289ce7de411717fd5a",
+    "content": "867237994656ede84fa9878ed0d15cb4bd009a9c560f3e15524a2e779f8c03fe"
+  },
+  "fastcdc|256K-512K-1M|repeat-2x-maxmax": {
+    "chunks": 32,
+    "cuts_hash": "6207c153ab65f7dd7da183e82ee7900c131f20f90e690d10e638d8896cee02e7",
+    "content": "1fdc2b342ea4e199bc5cbdba27958680eb2103a6580a823439d90f7ea2a90dba"
+  },
+  "fastcdc|256K-512K-1M|tiny-64": {
+    "chunks": 1,
+    "cuts_hash": "a06f129fc52abf6085679d7cd71dc41ec7580c7f5f73efef6d02dde22bb00994",
+    "content": "565966bd0e0cedaa92f154c2d17abfa4c5f98a668cef2e20b0855558e0583db9"
+  },
+  "fastcdc|256K-512K-1M|zeros-2x-maxmax": {
+    "chunks": 32,
+    "cuts_hash": "6207c153ab65f7dd7da183e82ee7900c131f20f90e690d10e638d8896cee02e7",
+    "content": "83ee47245398adee79bd9c0a8bc57b821e92aba10f5f9ade8a5d1fae4d8c4302"
+  },
+  "fastcdc|2K-8K-64K|empty": {
+    "chunks": 0,
+    "cuts_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "content": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  },
+  "fastcdc|2K-8K-64K|one-byte": {
+    "chunks": 1,
+    "cuts_hash": "7c9fa136d4413fa6173637e883b6998d32e1d675f88cddff9dcbcf331820f4b8",
+    "content": "df7e70e5021544f4834bbee64a9e3789febc4be81470df629cad6ddb03320a5c"
+  },
+  "fastcdc|2K-8K-64K|random-3x-maxmax": {
+    "chunks": 5382,
+    "cuts_hash": "545d89c340c72d930b35f982bf6c955062fa243ea1957031926d5b6538539f69",
+    "content": "867237994656ede84fa9878ed0d15cb4bd009a9c560f3e15524a2e779f8c03fe"
+  },
+  "fastcdc|2K-8K-64K|repeat-2x-maxmax": {
+    "chunks": 512,
+    "cuts_hash": "b985af207b5cbf7a3e6dfd235fbfff680cfac9e3f6cc399930f1e791924cd8f1",
+    "content": "1fdc2b342ea4e199bc5cbdba27958680eb2103a6580a823439d90f7ea2a90dba"
+  },
+  "fastcdc|2K-8K-64K|tiny-64": {
+    "chunks": 1,
+    "cuts_hash": "a06f129fc52abf6085679d7cd71dc41ec7580c7f5f73efef6d02dde22bb00994",
+    "content": "565966bd0e0cedaa92f154c2d17abfa4c5f98a668cef2e20b0855558e0583db9"
+  },
+  "fastcdc|2K-8K-64K|zeros-2x-maxmax": {
+    "chunks": 512,
+    "cuts_hash": "b985af207b5cbf7a3e6dfd235fbfff680cfac9e3f6cc399930f1e791924cd8f1",
+    "content": "83ee47245398adee79bd9c0a8bc57b821e92aba10f5f9ade8a5d1fae4d8c4302"
+  },
+  "jc-v1.0.0|1M-4M-16M|empty": {
+    "chunks": 0,
+    "cuts_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "content": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  },
+  "jc-v1.0.0|1M-4M-16M|one-byte": {
+    "chunks": 1,
+    "cuts_hash": "7c9fa136d4413fa6173637e883b6998d32e1d675f88cddff9dcbcf331820f4b8",
+    "content": "df7e70e5021544f4834bbee64a9e3789febc4be81470df629cad6ddb03320a5c"
+  },
+  "jc-v1.0.0|1M-4M-16M|random-3x-maxmax": {
+    "chunks": 6,
+    "cuts_hash": "eb81e8bba9c9639573c1ec71cb349cb20a65fea2d835f029ba94a7a760c3dc8f",
+    "content": "867237994656ede84fa9878ed0d15cb4bd009a9c560f3e15524a2e779f8c03fe"
+  },
+  "jc-v1.0.0|1M-4M-16M|repeat-2x-maxmax": {
+    "chunks": 2,
+    "cuts_hash": "8a2e77537c324b8ecfa4a28090b2c315d294926af6265bfacf6584bc310ea93e",
+    "content": "1fdc2b342ea4e199bc5cbdba27958680eb2103a6580a823439d90f7ea2a90dba"
+  },
+  "jc-v1.0.0|1M-4M-16M|tiny-64": {
+    "chunks": 1,
+    "cuts_hash": "a06f129fc52abf6085679d7cd71dc41ec7580c7f5f73efef6d02dde22bb00994",
+    "content": "565966bd0e0cedaa92f154c2d17abfa4c5f98a668cef2e20b0855558e0583db9"
+  },
+  "jc-v1.0.0|1M-4M-16M|zeros-2x-maxmax": {
+    "chunks": 2,
+    "cuts_hash": "8a2e77537c324b8ecfa4a28090b2c315d294926af6265bfacf6584bc310ea93e",
+    "content": "83ee47245398adee79bd9c0a8bc57b821e92aba10f5f9ade8a5d1fae4d8c4302"
+  },
+  "jc-v1.0.0|256K-512K-1M|empty": {
+    "chunks": 0,
+    "cuts_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "content": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  },
+  "jc-v1.0.0|256K-512K-1M|one-byte": {
+    "chunks": 1,
+    "cuts_hash": "7c9fa136d4413fa6173637e883b6998d32e1d675f88cddff9dcbcf331820f4b8",
+    "content": "df7e70e5021544f4834bbee64a9e3789febc4be81470df629cad6ddb03320a5c"
+  },
+  "jc-v1.0.0|256K-512K-1M|random-3x-maxmax": {
+    "chunks": 74,
+    "cuts_hash": "6426784ed5e75e2b0f4043de2e2c4da3b85b2fc2c8990eb38074496adf14ba1e",
+    "content": "867237994656ede84fa9878ed0d15cb4bd009a9c560f3e15524a2e779f8c03fe"
+  },
+  "jc-v1.0.0|256K-512K-1M|repeat-2x-maxmax": {
+    "chunks": 32,
+    "cuts_hash": "6207c153ab65f7dd7da183e82ee7900c131f20f90e690d10e638d8896cee02e7",
+    "content": "1fdc2b342ea4e199bc5cbdba27958680eb2103a6580a823439d90f7ea2a90dba"
+  },
+  "jc-v1.0.0|256K-512K-1M|tiny-64": {
+    "chunks": 1,
+    "cuts_hash": "a06f129fc52abf6085679d7cd71dc41ec7580c7f5f73efef6d02dde22bb00994",
+    "content": "565966bd0e0cedaa92f154c2d17abfa4c5f98a668cef2e20b0855558e0583db9"
+  },
+  "jc-v1.0.0|256K-512K-1M|zeros-2x-maxmax": {
+    "chunks": 32,
+    "cuts_hash": "6207c153ab65f7dd7da183e82ee7900c131f20f90e690d10e638d8896cee02e7",
+    "content": "83ee47245398adee79bd9c0a8bc57b821e92aba10f5f9ade8a5d1fae4d8c4302"
+  },
+  "jc-v1.0.0|2K-8K-64K|empty": {
+    "chunks": 0,
+    "cuts_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "content": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  },
+  "jc-v1.0.0|2K-8K-64K|one-byte": {
+    "chunks": 1,
+    "cuts_hash": "7c9fa136d4413fa6173637e883b6998d32e1d675f88cddff9dcbcf331820f4b8",
+    "content": "df7e70e5021544f4834bbee64a9e3789febc4be81470df629cad6ddb03320a5c"
+  },
+  "jc-v1.0.0|2K-8K-64K|random-3x-maxmax": {
+    "chunks": 6129,
+    "cuts_hash": "473d83b0c8a6562fe2ffce884c6fa0265c3c1858a7d45f16e58b6bc939b3cf8b",
+    "content": "867237994656ede84fa9878ed0d15cb4bd009a9c560f3e15524a2e779f8c03fe"
+  },
+  "jc-v1.0.0|2K-8K-64K|repeat-2x-maxmax": {
+    "chunks": 512,
+    "cuts_hash": "b985af207b5cbf7a3e6dfd235fbfff680cfac9e3f6cc399930f1e791924cd8f1",
+    "content": "1fdc2b342ea4e199bc5cbdba27958680eb2103a6580a823439d90f7ea2a90dba"
+  },
+  "jc-v1.0.0|2K-8K-64K|tiny-64": {
+    "chunks": 1,
+    "cuts_hash": "a06f129fc52abf6085679d7cd71dc41ec7580c7f5f73efef6d02dde22bb00994",
+    "content": "565966bd0e0cedaa92f154c2d17abfa4c5f98a668cef2e20b0855558e0583db9"
+  },
+  "jc-v1.0.0|2K-8K-64K|zeros-2x-maxmax": {
+    "chunks": 512,
+    "cuts_hash": "b985af207b5cbf7a3e6dfd235fbfff680cfac9e3f6cc399930f1e791924cd8f1",
+    "content": "83ee47245398adee79bd9c0a8bc57b821e92aba10f5f9ade8a5d1fae4d8c4302"
+  },
+  "jc|1M-4M-16M|empty": {
+    "chunks": 0,
+    "cuts_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "content": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  },
+  "jc|1M-4M-16M|one-byte": {
+    "chunks": 1,
+    "cuts_hash": "7c9fa136d4413fa6173637e883b6998d32e1d675f88cddff9dcbcf331820f4b8",
+    "content": "df7e70e5021544f4834bbee64a9e3789febc4be81470df629cad6ddb03320a5c"
+  },
+  "jc|1M-4M-16M|random-3x-maxmax": {
+    "chunks": 7,
+    "cuts_hash": "f6382e6eea32ba7f4d31a75fc889e6ce7563610f14ba3994639b639e3e05cd1d",
+    "content": "867237994656ede84fa9878ed0d15cb4bd009a9c560f3e15524a2e779f8c03fe"
+  },
+  "jc|1M-4M-16M|repeat-2x-maxmax": {
+    "chunks": 2,
+    "cuts_hash": "8a2e77537c324b8ecfa4a28090b2c315d294926af6265bfacf6584bc310ea93e",
+    "content": "1fdc2b342ea4e199bc5cbdba27958680eb2103a6580a823439d90f7ea2a90dba"
+  },
+  "jc|1M-4M-16M|tiny-64": {
+    "chunks": 1,
+    "cuts_hash": "a06f129fc52abf6085679d7cd71dc41ec7580c7f5f73efef6d02dde22bb00994",
+    "content": "565966bd0e0cedaa92f154c2d17abfa4c5f98a668cef2e20b0855558e0583db9"
+  },
+  "jc|1M-4M-16M|zeros-2x-maxmax": {
+    "chunks": 2,
+    "cuts_hash": "8a2e77537c324b8ecfa4a28090b2c315d294926af6265bfacf6584bc310ea93e",
+    "content": "83ee47245398adee79bd9c0a8bc57b821e92aba10f5f9ade8a5d1fae4d8c4302"
+  },
+  "jc|256K-512K-1M|empty": {
+    "chunks": 0,
+    "cuts_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "content": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  },
+  "jc|256K-512K-1M|one-byte": {
+    "chunks": 1,
+    "cuts_hash": "7c9fa136d4413fa6173637e883b6998d32e1d675f88cddff9dcbcf331820f4b8",
+    "content": "df7e70e5021544f4834bbee64a9e3789febc4be81470df629cad6ddb03320a5c"
+  },
+  "jc|256K-512K-1M|random-3x-maxmax": {
+    "chunks": 96,
+    "cuts_hash": "f5e4ab9642538d0182f715f042e0156dc242fbd95ce6c9b9bc8b12522dcb0c10",
+    "content": "867237994656ede84fa9878ed0d15cb4bd009a9c560f3e15524a2e779f8c03fe"
+  },
+  "jc|256K-512K-1M|repeat-2x-maxmax": {
+    "chunks": 32,
+    "cuts_hash": "6207c153ab65f7dd7da183e82ee7900c131f20f90e690d10e638d8896cee02e7",
+    "content": "1fdc2b342ea4e199bc5cbdba27958680eb2103a6580a823439d90f7ea2a90dba"
+  },
+  "jc|256K-512K-1M|tiny-64": {
+    "chunks": 1,
+    "cuts_hash": "a06f129fc52abf6085679d7cd71dc41ec7580c7f5f73efef6d02dde22bb00994",
+    "content": "565966bd0e0cedaa92f154c2d17abfa4c5f98a668cef2e20b0855558e0583db9"
+  },
+  "jc|256K-512K-1M|zeros-2x-maxmax": {
+    "chunks": 32,
+    "cuts_hash": "6207c153ab65f7dd7da183e82ee7900c131f20f90e690d10e638d8896cee02e7",
+    "content": "83ee47245398adee79bd9c0a8bc57b821e92aba10f5f9ade8a5d1fae4d8c4302"
+  },
+  "jc|2K-8K-64K|empty": {
+    "chunks": 0,
+    "cuts_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "content": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  },
+  "jc|2K-8K-64K|one-byte": {
+    "chunks": 1,
+    "cuts_hash": "7c9fa136d4413fa6173637e883b6998d32e1d675f88cddff9dcbcf331820f4b8",
+    "content": "df7e70e5021544f4834bbee64a9e3789febc4be81470df629cad6ddb03320a5c"
+  },
+  "jc|2K-8K-64K|random-3x-maxmax": {
+    "chunks": 6129,
+    "cuts_hash": "473d83b0c8a6562fe2ffce884c6fa0265c3c1858a7d45f16e58b6bc939b3cf8b",
+    "content": "867237994656ede84fa9878ed0d15cb4bd009a9c560f3e15524a2e779f8c03fe"
+  },
+  "jc|2K-8K-64K|repeat-2x-maxmax": {
+    "chunks": 512,
+    "cuts_hash": "b985af207b5cbf7a3e6dfd235fbfff680cfac9e3f6cc399930f1e791924cd8f1",
+    "content": "1fdc2b342ea4e199bc5cbdba27958680eb2103a6580a823439d90f7ea2a90dba"
+  },
+  "jc|2K-8K-64K|tiny-64": {
+    "chunks": 1,
+    "cuts_hash": "a06f129fc52abf6085679d7cd71dc41ec7580c7f5f73efef6d02dde22bb00994",
+    "content": "565966bd0e0cedaa92f154c2d17abfa4c5f98a668cef2e20b0855558e0583db9"
+  },
+  "jc|2K-8K-64K|zeros-2x-maxmax": {
+    "chunks": 512,
+    "cuts_hash": "b985af207b5cbf7a3e6dfd235fbfff680cfac9e3f6cc399930f1e791924cd8f1",
+    "content": "83ee47245398adee79bd9c0a8bc57b821e92aba10f5f9ade8a5d1fae4d8c4302"
+  },
+  "kfastcdc|1M-4M-16M|empty": {
+    "chunks": 0,
+    "cuts_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "content": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  },
+  "kfastcdc|1M-4M-16M|one-byte": {
+    "chunks": 1,
+    "cuts_hash": "7c9fa136d4413fa6173637e883b6998d32e1d675f88cddff9dcbcf331820f4b8",
+    "content": "df7e70e5021544f4834bbee64a9e3789febc4be81470df629cad6ddb03320a5c"
+  },
+  "kfastcdc|1M-4M-16M|random-3x-maxmax": {
+    "chunks": 47,
+    "cuts_hash": "cbd21e1ae737cd03c952d64ec93831f0af5615b317dd99976f74604bc50eb0a8",
+    "content": "867237994656ede84fa9878ed0d15cb4bd009a9c560f3e15524a2e779f8c03fe"
+  },
+  "kfastcdc|1M-4M-16M|repeat-2x-maxmax": {
+    "chunks": 2,
+    "cuts_hash": "8a2e77537c324b8ecfa4a28090b2c315d294926af6265bfacf6584bc310ea93e",
+    "content": "1fdc2b342ea4e199bc5cbdba27958680eb2103a6580a823439d90f7ea2a90dba"
+  },
+  "kfastcdc|1M-4M-16M|tiny-64": {
+    "chunks": 1,
+    "cuts_hash": "a06f129fc52abf6085679d7cd71dc41ec7580c7f5f73efef6d02dde22bb00994",
+    "content": "565966bd0e0cedaa92f154c2d17abfa4c5f98a668cef2e20b0855558e0583db9"
+  },
+  "kfastcdc|1M-4M-16M|zeros-2x-maxmax": {
+    "chunks": 2,
+    "cuts_hash": "8a2e77537c324b8ecfa4a28090b2c315d294926af6265bfacf6584bc310ea93e",
+    "content": "83ee47245398adee79bd9c0a8bc57b821e92aba10f5f9ade8a5d1fae4d8c4302"
+  },
+  "kfastcdc|256K-512K-1M|empty": {
+    "chunks": 0,
+    "cuts_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "content": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  },
+  "kfastcdc|256K-512K-1M|one-byte": {
+    "chunks": 1,
+    "cuts_hash": "7c9fa136d4413fa6173637e883b6998d32e1d675f88cddff9dcbcf331820f4b8",
+    "content": "df7e70e5021544f4834bbee64a9e3789febc4be81470df629cad6ddb03320a5c"
+  },
+  "kfastcdc|256K-512K-1M|random-3x-maxmax": {
+    "chunks": 173,
+    "cuts_hash": "3f9eb53caa83e227ead774ba2bc9c95d710b86dd7f02e6156ed84513032f4c59",
+    "content": "867237994656ede84fa9878ed0d15cb4bd009a9c560f3e15524a2e779f8c03fe"
+  },
+  "kfastcdc|256K-512K-1M|repeat-2x-maxmax": {
+    "chunks": 32,
+    "cuts_hash": "6207c153ab65f7dd7da183e82ee7900c131f20f90e690d10e638d8896cee02e7",
+    "content": "1fdc2b342ea4e199bc5cbdba27958680eb2103a6580a823439d90f7ea2a90dba"
+  },
+  "kfastcdc|256K-512K-1M|tiny-64": {
+    "chunks": 1,
+    "cuts_hash": "a06f129fc52abf6085679d7cd71dc41ec7580c7f5f73efef6d02dde22bb00994",
+    "content": "565966bd0e0cedaa92f154c2d17abfa4c5f98a668cef2e20b0855558e0583db9"
+  },
+  "kfastcdc|256K-512K-1M|zeros-2x-maxmax": {
+    "chunks": 32,
+    "cuts_hash": "6207c153ab65f7dd7da183e82ee7900c131f20f90e690d10e638d8896cee02e7",
+    "content": "83ee47245398adee79bd9c0a8bc57b821e92aba10f5f9ade8a5d1fae4d8c4302"
+  },
+  "kfastcdc|2K-8K-64K|empty": {
+    "chunks": 0,
+    "cuts_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "content": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  },
+  "kfastcdc|2K-8K-64K|one-byte": {
+    "chunks": 1,
+    "cuts_hash": "7c9fa136d4413fa6173637e883b6998d32e1d675f88cddff9dcbcf331820f4b8",
+    "content": "df7e70e5021544f4834bbee64a9e3789febc4be81470df629cad6ddb03320a5c"
+  },
+  "kfastcdc|2K-8K-64K|random-3x-maxmax": {
+    "chunks": 5402,
+    "cuts_hash": "8fa6adb1765660d037ac6ebdadc5fcbcb86f997e82a7a3abb1962ea9679b5db6",
+    "content": "867237994656ede84fa9878ed0d15cb4bd009a9c560f3e15524a2e779f8c03fe"
+  },
+  "kfastcdc|2K-8K-64K|repeat-2x-maxmax": {
+    "chunks": 512,
+    "cuts_hash": "b985af207b5cbf7a3e6dfd235fbfff680cfac9e3f6cc399930f1e791924cd8f1",
+    "content": "1fdc2b342ea4e199bc5cbdba27958680eb2103a6580a823439d90f7ea2a90dba"
+  },
+  "kfastcdc|2K-8K-64K|tiny-64": {
+    "chunks": 1,
+    "cuts_hash": "a06f129fc52abf6085679d7cd71dc41ec7580c7f5f73efef6d02dde22bb00994",
+    "content": "565966bd0e0cedaa92f154c2d17abfa4c5f98a668cef2e20b0855558e0583db9"
+  },
+  "kfastcdc|2K-8K-64K|zeros-2x-maxmax": {
+    "chunks": 512,
+    "cuts_hash": "b985af207b5cbf7a3e6dfd235fbfff680cfac9e3f6cc399930f1e791924cd8f1",
+    "content": "83ee47245398adee79bd9c0a8bc57b821e92aba10f5f9ade8a5d1fae4d8c4302"
+  },
+  "ultracdc|1M-4M-16M|empty": {
+    "chunks": 0,
+    "cuts_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "content": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  },
+  "ultracdc|1M-4M-16M|one-byte": {
+    "chunks": 1,
+    "cuts_hash": "7c9fa136d4413fa6173637e883b6998d32e1d675f88cddff9dcbcf331820f4b8",
+    "content": "df7e70e5021544f4834bbee64a9e3789febc4be81470df629cad6ddb03320a5c"
+  },
+  "ultracdc|1M-4M-16M|random-3x-maxmax": {
+    "chunks": 46,
+    "cuts_hash": "bb22755478c2ed686f1c647c736187a7a1d4938ada72b8707302556bf0fbfc78",
+    "content": "867237994656ede84fa9878ed0d15cb4bd009a9c560f3e15524a2e779f8c03fe"
+  },
+  "ultracdc|1M-4M-16M|repeat-2x-maxmax": {
+    "chunks": 2,
+    "cuts_hash": "8a2e77537c324b8ecfa4a28090b2c315d294926af6265bfacf6584bc310ea93e",
+    "content": "1fdc2b342ea4e199bc5cbdba27958680eb2103a6580a823439d90f7ea2a90dba"
+  },
+  "ultracdc|1M-4M-16M|tiny-64": {
+    "chunks": 1,
+    "cuts_hash": "a06f129fc52abf6085679d7cd71dc41ec7580c7f5f73efef6d02dde22bb00994",
+    "content": "565966bd0e0cedaa92f154c2d17abfa4c5f98a668cef2e20b0855558e0583db9"
+  },
+  "ultracdc|1M-4M-16M|zeros-2x-maxmax": {
+    "chunks": 32,
+    "cuts_hash": "b5ffa1aa6363c62e902936f3d2018f5ad6c299ad9bd94a99b54e39418cc7e418",
+    "content": "83ee47245398adee79bd9c0a8bc57b821e92aba10f5f9ade8a5d1fae4d8c4302"
+  },
+  "ultracdc|256K-512K-1M|empty": {
+    "chunks": 0,
+    "cuts_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "content": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  },
+  "ultracdc|256K-512K-1M|one-byte": {
+    "chunks": 1,
+    "cuts_hash": "7c9fa136d4413fa6173637e883b6998d32e1d675f88cddff9dcbcf331820f4b8",
+    "content": "df7e70e5021544f4834bbee64a9e3789febc4be81470df629cad6ddb03320a5c"
+  },
+  "ultracdc|256K-512K-1M|random-3x-maxmax": {
+    "chunks": 162,
+    "cuts_hash": "876756adb9ce3ca631f7e2589da2618453438075e7d77007dad1f5a3b610a176",
+    "content": "867237994656ede84fa9878ed0d15cb4bd009a9c560f3e15524a2e779f8c03fe"
+  },
+  "ultracdc|256K-512K-1M|repeat-2x-maxmax": {
+    "chunks": 32,
+    "cuts_hash": "6207c153ab65f7dd7da183e82ee7900c131f20f90e690d10e638d8896cee02e7",
+    "content": "1fdc2b342ea4e199bc5cbdba27958680eb2103a6580a823439d90f7ea2a90dba"
+  },
+  "ultracdc|256K-512K-1M|tiny-64": {
+    "chunks": 1,
+    "cuts_hash": "a06f129fc52abf6085679d7cd71dc41ec7580c7f5f73efef6d02dde22bb00994",
+    "content": "565966bd0e0cedaa92f154c2d17abfa4c5f98a668cef2e20b0855558e0583db9"
+  },
+  "ultracdc|256K-512K-1M|zeros-2x-maxmax": {
+    "chunks": 128,
+    "cuts_hash": "050c9696531cd20f8730ade0ee70aa9db3ab038eed31afd1cbef758a70bdc988",
+    "content": "83ee47245398adee79bd9c0a8bc57b821e92aba10f5f9ade8a5d1fae4d8c4302"
+  },
+  "ultracdc|2K-8K-64K|empty": {
+    "chunks": 0,
+    "cuts_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "content": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  },
+  "ultracdc|2K-8K-64K|one-byte": {
+    "chunks": 1,
+    "cuts_hash": "7c9fa136d4413fa6173637e883b6998d32e1d675f88cddff9dcbcf331820f4b8",
+    "content": "df7e70e5021544f4834bbee64a9e3789febc4be81470df629cad6ddb03320a5c"
+  },
+  "ultracdc|2K-8K-64K|random-3x-maxmax": {
+    "chunks": 5174,
+    "cuts_hash": "5b69a7dd50426e3b7d01d48536941095f57b1fd8a77e6d9ab9be11b24c4f3467",
+    "content": "867237994656ede84fa9878ed0d15cb4bd009a9c560f3e15524a2e779f8c03fe"
+  },
+  "ultracdc|2K-8K-64K|repeat-2x-maxmax": {
+    "chunks": 512,
+    "cuts_hash": "b985af207b5cbf7a3e6dfd235fbfff680cfac9e3f6cc399930f1e791924cd8f1",
+    "content": "1fdc2b342ea4e199bc5cbdba27958680eb2103a6580a823439d90f7ea2a90dba"
+  },
+  "ultracdc|2K-8K-64K|tiny-64": {
+    "chunks": 1,
+    "cuts_hash": "a06f129fc52abf6085679d7cd71dc41ec7580c7f5f73efef6d02dde22bb00994",
+    "content": "565966bd0e0cedaa92f154c2d17abfa4c5f98a668cef2e20b0855558e0583db9"
+  },
+  "ultracdc|2K-8K-64K|zeros-2x-maxmax": {
+    "chunks": 13067,
+    "cuts_hash": "fd3ea3181fb1b999ad3fb807e3556548883bf890774d2df388fd4fb2cac2fab3",
+    "content": "83ee47245398adee79bd9c0a8bc57b821e92aba10f5f9ade8a5d1fae4d8c4302"
+  }
+}


### PR DESCRIPTION
Adds testing and tooling only. No chunker implementation is touched — the
library code and `go.mod` are byte-identical to `main`.

Split by commit:

- **idempotency golden oracle + shared harness** — a compact fingerprint
  (cutpoint-length digest + content digest) for every algorithm across three
  size profiles and a battery of boundary inputs. The reference any future
  change must reproduce byte for byte. Regenerate with
  `go test ./tests/ -run TestGolden -update`.
- **FastCDC reference-equivalence guard** — a frozen copy of the inner loop;
  asserts the live `Algorithm` matches it cutpoint-for-cutpoint (keyed and
  unkeyed).
- **JC and UltraCDC reference-equivalence guards** — same for both; the
  UltraCDC one documents the window-capacity precondition.
- **`cmd/cdc` tool** — dependency-free CLI (imports only this library):
  - `analyze` — dedup ratio, chunk-size distribution, throughput
  - `compare -a -b` — side-by-side, non-zero exit on dedup regression (CI gate)
  - `resync -a -b` — shared-chunk %% after small edits (the content-defined
    property dedup relies on)
- **`cmd/cdcplot` tool** — renders the above as PNG graphs, one set per
  implementation (chunk-size distribution, CDF, resync curve, dedup sweep). It
  is its own module so its plotting dependency (gonum) is never pulled into the
  library or the `cdc` CLI.
- **docs** — refresh the stale benchmark table with current numbers and
  document the tools.

These give an objective way to tell whether a chunker change is identical,
better, or a regression — and lock the current behaviour in so later
performance work can be proven output-preserving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)