### PR TITLE
readme: add pkg.go.dev reference badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # go-cdc-chunkers
 
+[![Go Reference](https://pkg.go.dev/badge/github.com/PlakarKorp/go-cdc-chunkers.svg)](https://pkg.go.dev/github.com/PlakarKorp/go-cdc-chunkers)
+
 This is an active project !
 
 Read our announcement post here: [Introducing go-cdc-chunkers: chunk and deduplicate everything](https://plakar.io/posts/2025-07-11/introducing-go-cdc-chunkers-chunk-and-deduplicate-everything/)


### PR DESCRIPTION
#20 asked for a GoDoc link in the readme to browse the public API. adds
the standard pkg.go.dev reference badge under the title — module is
already indexed, both the badge and the link resolve (200).

closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)