### PR TITLE
Refresh benchmarks; add Codecov + Go Report Card badges and coverage CI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,19 +13,23 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        go: [ '1.23.4' ]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v5
       with:
-        go-version: ${{ matrix.go }}
+        go-version-file: 'go.mod'
+        check-latest: true
 
     - name: Build
       run: go build -v ./...
 
     - name: Test
-      run: go test -v ./...
+      run: go test -v -coverprofile=coverage.out -covermode=atomic -timeout 5m ./...
+
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v4
+      with:
+        files: ./coverage.out
+        fail_ci_if_error: false

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # go-cdc-chunkers
 
 [![Go Reference](https://pkg.go.dev/badge/github.com/PlakarKorp/go-cdc-chunkers.svg)](https://pkg.go.dev/github.com/PlakarKorp/go-cdc-chunkers)
+[![Go Report Card](https://goreportcard.com/badge/github.com/PlakarKorp/go-cdc-chunkers)](https://goreportcard.com/report/github.com/PlakarKorp/go-cdc-chunkers)
+[![codecov](https://codecov.io/gh/PlakarKorp/go-cdc-chunkers/branch/main/graph/badge.svg)](https://codecov.io/gh/PlakarKorp/go-cdc-chunkers)
+[![Go](https://github.com/PlakarKorp/go-cdc-chunkers/actions/workflows/go.yml/badge.svg)](https://github.com/PlakarKorp/go-cdc-chunkers/actions/workflows/go.yml)
 
 This is an active project !
 
@@ -73,17 +76,17 @@ cpu: Apple M4 Pro
 
 | Implementation              | Throughput | Chunks  | B/op      | allocs/op |
 | --------------------------- | ---------: | ------: | --------: | --------: |
-| PlakarKorp JC (v1.1.0)      | 3764 MB/s  | 130,901 |   133,562 |         5 |
-| PlakarKorp JC (legacy)      | 3747 MB/s  | 130,901 |   133,562 |         5 |
-| Tigerwill90 FastCDC         | 2419 MB/s  | 129,246 |   131,248 |         3 |
-| PlakarKorp KeyedFastCDC     | 2247 MB/s  | 114,804 |   146,693 |         8 |
-| PlakarKorp FastCDC          | 2242 MB/s  | 114,876 |   133,562 |         5 |
-| Jotfs FastCDC               | 2216 MB/s  | 117,043 |   131,184 |         2 |
-| Mhofmann FastCDC            | 2213 MB/s  | 114,930 |    65,648 |         2 |
-| Askeladdk FastCDC           | 2200 MB/s  | 105,327 |    43,701 |         1 |
-| PlakarKorp UltraCDC (legacy)| 1833 MB/s  |  94,207 |   131,264 |         5 |
-| PlakarKorp UltraCDC (v1.0.0)| 1794 MB/s  |  94,169 |   131,258 |         5 |
-| Restic Rabin                |  497 MB/s  |  16,880 | 3,329,674 |        30 |
+| PlakarKorp JC (v1.1.0)      | 3747 MB/s  | 130,901 |   131,306 |         5 |
+| PlakarKorp JC (legacy)      | 3658 MB/s  | 130,901 |   131,306 |         5 |
+| Tigerwill90 FastCDC         | 2412 MB/s  | 129,246 |   131,248 |         3 |
+| Jotfs FastCDC               | 2242 MB/s  | 117,043 |   131,184 |         2 |
+| PlakarKorp KeyedFastCDC     | 2229 MB/s  | 114,955 |   136,453 |         7 |
+| Askeladdk FastCDC           | 2224 MB/s  | 105,327 |    43,701 |         1 |
+| PlakarKorp FastCDC          | 2213 MB/s  | 114,876 |   131,306 |         5 |
+| Mhofmann FastCDC            | 2188 MB/s  | 114,930 |    65,648 |         2 |
+| PlakarKorp UltraCDC (v1.0.0)| 1821 MB/s  |  94,169 |   131,264 |         5 |
+| PlakarKorp UltraCDC (legacy)| 1798 MB/s  |  94,207 |   131,264 |         5 |
+| Restic Rabin                |  497 MB/s  |  16,875 | 3,329,797 |        46 |
 
 > Throughput is not the whole story: implementations cut at different average
 > sizes for identical options, and a faster chunker is only useful if its


### PR DESCRIPTION
## README — benchmarks

Refreshed the comparison table (Apple M4 Pro, 1 GiB random) now that the gear-table sharing (`getGearTable` + keyed cache, #35) is merged:

- PlakarKorp entries drop **~133.5 KB → ~131.3 KB** B/op — the 2 KiB per-chunker Gear-table copy is gone; the remaining footprint is the `2×MaxSize` scan buffer (poolable via `NewChunkerBuffer`).
- Keyed FastCDC drops further (~146 KB → ~136 KB) since the derived table is now cached rather than copied per chunker.

## README — badges

Added **Go Report Card**, **Codecov**, and **CI status** badges alongside the existing Go Reference badge, matching [PlakarKorp/kloset](https://github.com/PlakarKorp/kloset).

## CI — coverage + Codecov

`.github/workflows/go.yml`:
- Generates a coverage profile and uploads it to Codecov (`codecov-action@v4`), mirroring kloset's workflow so the badge has data.
- Modernized `checkout@v2 → v4`, `setup-go@v2 → v5` (using `go-version-file` so the toolchain tracks `go.mod`), and dropped the single-entry version matrix.
- **Coverage run is without `-race`:** the `tests/` package processes large inputs (~10 s/test) and under race instrumentation overruns the CI time budget (`Test_UltraCDC_Copy` timed out at 3 m in local testing). `-timeout` raised to 5 m for headroom; without `-race` the full suite finishes in ~40 s and passes. (This matches kloset, which also runs coverage without `-race`.)

## Follow-up needed (dashboard, not code)

The Codecov badge will show "unknown" until the repo is enabled on **codecov.io** and the first `main`-branch coverage upload lands. For a private repo a `CODECOV_TOKEN` secret is also required; for a public repo tokenless upload works. No code change needed on this side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)