### PR TITLE
Add codecov.yml to scope coverage to the library

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,21 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
+
+comment: false
+
+# Coverage should reflect the importable library only. The command-line tools,
+# internal test helpers, profiling harnesses, the benchmark module, and the
+# end-to-end tests directory are not part of the library API and would
+# otherwise drag the reported number down.
+ignore:
+  - "cmd/**/*"
+  - "internal/**/*"
+  - "profiling/**/*"
+  - "benchmarks/**/*"
+  - "tests/**/*"


### PR DESCRIPTION
The `codecov.yml` was authored on the #36 branch but only *after* #36 was merged, so it never landed on `main` — which is why Codecov still reports ~58%.

This brings it in on its own. It ignores the non-library trees (`cmd/`, `internal/`, `profiling/`, `benchmarks/`, `tests/`) — none of which are part of the importable API and which were dragging the number down with 0% coverage. With them excluded, reported coverage reflects the library itself: **~97%** over the root package + `chunkers/*` (algorithms at 100%; remainder is error paths in `chunkers.go`/`reader.go`).

Statuses are `informational` (no CI gate on coverage deltas) and PR comments disabled, matching [PlakarKorp/kloset](https://github.com/PlakarKorp/kloset).

Codecov picks up the config on the next `main`-branch upload after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)