### PR TITLE
Bring library coverage to 100%

### DIFF
--- a/chunkers/fixed/fixed.go
+++ b/chunkers/fixed/fixed.go
@@ -26,10 +26,6 @@ func init() {
 	chunkers.Register("fixed-v1.0.0", newFixed)
 }
 
-var readDigest = func(r interface{ Read([]byte) (int, error) }, p []byte) (int, error) {
-	return r.Read(p)
-}
-
 var ErrNotPowerOfTwo = errors.New("ChunkSize must be a power of two")
 var ErrChunkSize = errors.New("ChunkSize is required and must be 64B <= ChunkSize <= 1GB")
 var ErrFixedSize = errors.New("a fixed chunker uses a single size: MinSize and MaxSize must equal NormalSize")

--- a/coverage_test.go
+++ b/coverage_test.go
@@ -1,0 +1,152 @@
+package chunkers
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"testing"
+)
+
+// errSetupImpl is an implementation whose Setup always fails, to exercise the
+// Setup-error paths of the constructors.
+type errSetupImpl struct{}
+
+func (errSetupImpl) DefaultOptions() *ChunkerOpts {
+	return &ChunkerOpts{MinSize: 8, NormalSize: 16, MaxSize: 64}
+}
+func (errSetupImpl) Setup(_ *ChunkerOpts) error                    { return errors.New("setup failed") }
+func (errSetupImpl) Validate(_ *ChunkerOpts) error                 { return nil }
+func (errSetupImpl) Algorithm(_ *ChunkerOpts, _ []byte, n int) int { return n }
+
+func init() {
+	_ = Register("errsetup", func() ChunkerImplementation { return errSetupImpl{} })
+}
+
+// errReader returns an error (not io.EOF) partway through, to exercise the
+// non-EOF read-error branches of Next/Copy/Split.
+type errReader struct {
+	data []byte
+	pos  int
+	fail int // byte offset at which to return the error
+}
+
+func (r *errReader) Read(p []byte) (int, error) {
+	if r.pos >= r.fail {
+		return 0, errors.New("read boom")
+	}
+	n := copy(p, r.data[r.pos:min(r.fail, len(r.data))])
+	r.pos += n
+	return n, nil
+}
+
+// failWriter fails on Write, to exercise Copy's writer-error branch.
+type failWriter struct{}
+
+func (failWriter) Write(_ []byte) (int, error) { return 0, errors.New("write boom") }
+
+// TestNewChunker_NormalSizeDefaulted covers the NormalSize defaulting branch
+// (opts non-nil with NormalSize==0 but Min/Max set).
+func TestNewChunker_NormalSizeDefaulted(t *testing.T) {
+	c, err := NewChunker("testimpl", bytes.NewReader(nil), &ChunkerOpts{MinSize: 8, MaxSize: 64})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c.NormalSize() != 16 { // testimpl default
+		t.Fatalf("NormalSize not defaulted: got %d", c.NormalSize())
+	}
+}
+
+// TestNewChunker_SetupError covers the Setup-error return in NewChunker.
+func TestNewChunker_SetupError(t *testing.T) {
+	if _, err := NewChunker("errsetup", bytes.NewReader(nil), nil); err == nil {
+		t.Fatal("expected Setup error from NewChunker")
+	}
+}
+
+// TestNewChunkerBuffer_UnknownAlgorithm covers the newChunker-error return in
+// NewChunkerBuffer (before the buffer-size check).
+func TestNewChunkerBuffer_UnknownAlgorithm(t *testing.T) {
+	if _, err := NewChunkerBuffer("nope-not-registered", bytes.NewReader(nil), nil, make([]byte, 1<<20)); err == nil {
+		t.Fatal("expected unknown-algorithm error")
+	}
+}
+
+// TestNext_ReadError covers Next's non-EOF read-error branch.
+func TestNext_ReadError(t *testing.T) {
+	r := &errReader{data: make([]byte, 8), fail: 4}
+	c, err := NewChunker("testimpl", r, &ChunkerOpts{MinSize: 8, NormalSize: 16, MaxSize: 64})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := c.Next(); err == nil {
+		t.Fatal("expected read error from Next")
+	}
+}
+
+// TestCopy_ReadError covers Copy's non-EOF error propagation.
+func TestCopy_ReadError(t *testing.T) {
+	r := &errReader{data: make([]byte, 8), fail: 4}
+	c, _ := NewChunker("testimpl", r, &ChunkerOpts{MinSize: 8, NormalSize: 16, MaxSize: 64})
+	if _, err := c.Copy(&bytes.Buffer{}); err == nil {
+		t.Fatal("expected read error from Copy")
+	}
+}
+
+// TestCopy_WriteError covers Copy's writer-error branch.
+func TestCopy_WriteError(t *testing.T) {
+	c, _ := NewChunker("testimpl", bytes.NewReader(makeData(128)), &ChunkerOpts{MinSize: 8, NormalSize: 16, MaxSize: 64})
+	if _, err := c.Copy(failWriter{}); err == nil {
+		t.Fatal("expected write error from Copy")
+	}
+}
+
+// TestSplit_ReadError covers Split's non-EOF error propagation.
+func TestSplit_ReadError(t *testing.T) {
+	r := &errReader{data: make([]byte, 8), fail: 4}
+	c, _ := NewChunker("testimpl", r, &ChunkerOpts{MinSize: 8, NormalSize: 16, MaxSize: 64})
+	err := c.Split(func(_, _ uint, _ []byte) error { return nil })
+	if err == nil {
+		t.Fatal("expected read error from Split")
+	}
+}
+
+// TestSplit_CallbackError covers Split's callback-error branch.
+func TestSplit_CallbackError(t *testing.T) {
+	c, _ := NewChunker("testimpl", bytes.NewReader(makeData(128)), &ChunkerOpts{MinSize: 8, NormalSize: 16, MaxSize: 64})
+	want := errors.New("callback boom")
+	err := c.Split(func(_, _ uint, _ []byte) error { return want })
+	if !errors.Is(err, want) {
+		t.Fatalf("expected callback error, got %v", err)
+	}
+}
+
+// zeroForeverReader always returns (0, nil): the pathological no-progress case
+// the peek guard must break out of with io.ErrNoProgress.
+type zeroForeverReader struct{}
+
+func (zeroForeverReader) Read(_ []byte) (int, error) { return 0, nil }
+
+// TestPeek_NoProgress covers reader.go's maxConsecutiveEmptyReads guard
+// (tries <= 1 -> io.ErrNoProgress).
+func TestPeek_NoProgress(t *testing.T) {
+	var cr bufReader
+	cr.reset(zeroForeverReader{}, make([]byte, 64))
+	_, err := cr.peek(32)
+	if !errors.Is(err, io.ErrNoProgress) {
+		t.Fatalf("expected io.ErrNoProgress, got %v", err)
+	}
+}
+
+// TestPeek_EOFFallback covers the peek branch where the source ends with a
+// clean (0, io.EOF) so cr.err is io.EOF and the short-read path returns it.
+func TestPeek_EOFFallback(t *testing.T) {
+	var cr bufReader
+	cr.reset(bytes.NewReader([]byte("12345")), make([]byte, 64))
+	data, err := cr.peek(32) // ask for more than available
+	if err != io.EOF {
+		t.Fatalf("expected io.EOF on short read, got %v", err)
+	}
+	if string(data) != "12345" {
+		t.Fatalf("expected the 5 available bytes, got %q", data)
+	}
+}

--- a/reader.go
+++ b/reader.go
@@ -88,12 +88,9 @@ func (cr *bufReader) peek(n int) ([]byte, error) {
 	}
 	window := cr.buf[cr.r : cr.r+avail]
 	if avail < n {
-		// Not enough data: surface the pending error (EOF or otherwise).
-		err := cr.err
-		if err == nil {
-			err = io.EOF
-		}
-		return window, err
+		// Short read: the fill loop only exits early once cr.err is set, so
+		// it is non-nil here (io.EOF in the normal case, or a read error).
+		return window, cr.err
 	}
 	return window, nil
 }


### PR DESCRIPTION
Closes the remaining coverage gaps so the library (root package + `chunkers/*`, matching `codecov.yml`) is at **100.0%**, up from the previously uncovered branches in `chunkers.go` (83%), `reader.go` (86%), and `chunkers/fixed` (93%).

## What was uncovered, and how it's addressed

**`coverage_test.go` (new)** — exercises the public-API error/edge branches that lacked tests:
- `NewChunker` NormalSize defaulting (opts with `NormalSize==0`, Min/Max set)
- `NewChunker` Setup-error return (new `errsetup` test impl)
- `NewChunkerBuffer` unknown-algorithm return (before the buffer-size check)
- non-EOF read errors in `Next`, `Copy`, `Split`
- `Copy` writer error; `Split` callback error
- `bufReader` no-progress guard (`io.ErrNoProgress`) and the short-read EOF path

**`reader.go`** — the `peek` short-read path had `if err == nil { err = io.EOF }`, which is **unreachable**: the fill loop only exits early once `cr.err` is set, so `cr.err` is always non-nil there. Collapsed to `return window, cr.err` (simpler and fully covered).

**`chunkers/fixed/fixed.go`** — removed the unused `readDigest` indirection hook (copy-paste leftover from the keyed fastcdc/jc template; the fixed chunker has no keyed path, so it was dead code dragging the package to 93%).

## Verification

- Library total: **100.0%**, zero uncovered blocks (verified over the codecov-ignored-set: root + `chunkers/*`).
- Full suite passes under `-race` (125 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)