### PR TITLE
Fix codecov ignore: exclude top-level files in non-library dirs

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -15,7 +15,12 @@ comment: false
 # otherwise drag the reported number down.
 ignore:
   - "cmd/**/*"
+  - "cmd/*"
   - "internal/**/*"
+  - "internal/*"
   - "profiling/**/*"
+  - "profiling/*"
   - "benchmarks/**/*"
+  - "benchmarks/*"
   - "tests/**/*"
+  - "tests/*"


### PR DESCRIPTION
The `dir/**/*` ignore globs in `codecov.yml` only match files in **subdirectories** — a file sitting directly in the directory was still counted.

`profiling/profiling.go` (a 0%-covered `main` profiling harness) lives at the top level of `profiling/`, so `profiling/**/*` didn't match it and it was dragging the reported coverage down. Same latent gap for `benchmarks/*.go` and `tests/*.go` (those are outside the Go coverage profile anyway, but fixed for consistency).

Fix: add the companion `dir/*` pattern for each ignored directory, matching [kloset](https://github.com/PlakarKorp/kloset)'s style (it lists both `testing/**/*` and `testing/*`).

The library figure is unaffected — it stays at **100%**; this just stops `profiling/profiling.go` from being silently averaged in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)