### PR TITLE
ci: enable Codecov Test Analytics (JUnit upload)

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 2
 
     - name: Set up Go
       uses: actions/setup-go@v5
@@ -25,11 +27,42 @@ jobs:
     - name: Build
       run: go build -v ./...
 
+    # Run the tests producing both a coverage profile (for Codecov coverage)
+    # and a JUnit XML (for Codecov Test Analytics). go-junit-report converts
+    # `go test -json` output into JUnit. We must not let a test failure abort
+    # the job, otherwise the upload steps below would be skipped and we'd lose
+    # the very results that explain the failure — `set -o pipefail` plus an
+    # explicit exit captures the test outcome for the final step.
     - name: Test
-      run: go test -v -coverprofile=coverage.out -covermode=atomic -timeout 5m ./...
+      id: gotest
+      continue-on-error: true
+      run: |
+        go install github.com/jstemmer/go-junit-report/v2@latest
+        set -o pipefail
+        go test -v -coverprofile=coverage.out -covermode=atomic -timeout 5m -json ./... \
+          | "$(go env GOPATH)/bin/go-junit-report" -parser gojson -set-exit-code > junit.xml
+        status=$?
+        echo "test_exit=$status" >> "$GITHUB_OUTPUT"
+        exit $status
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v5
       with:
+        # Tokenless upload works for public repos; the token is used when the
+        # CODECOV_TOKEN secret is present (required for private repos and to
+        # avoid tokenless rate limits).
+        token: ${{ secrets.CODECOV_TOKEN }}
         files: ./coverage.out
         fail_ci_if_error: false
+
+    - name: Upload test results to Codecov
+      if: ${{ !cancelled() }}
+      uses: codecov/test-results-action@v1
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: ./junit.xml
+
+    # Surface a genuine test failure now that the results have been uploaded.
+    - name: Fail if tests failed
+      if: ${{ steps.gotest.outputs.test_exit != '0' }}
+      run: exit 1


### PR DESCRIPTION
Adapts [Codecov's Test Analytics recipe](https://docs.codecov.com/docs/test-analytics) to this Go repo — their example is pytest/JUnit; the Go equivalent produces JUnit XML from `go test -json`.

## How the snippet maps to Go

| Codecov's pytest example | Go equivalent here |
| --- | --- |
| `pytest --cov --junitxml=junit.xml` | `go test -json … \| go-junit-report > junit.xml` (plus the existing `-coverprofile`) |
| `codecov/codecov-action@v5` | bumped from v4 → v5 |
| `codecov/test-results-action@v1` | added, uploads `junit.xml` |
| `fetch-depth: 2` | added to `checkout` |

## Merged into the existing job (not a second job)

No need for a separate checkout/setup — the steps slot into the current `build` job:

- **Test** runs `go test -json` piped through `jstemmer/go-junit-report` (`-set-exit-code`) to emit `junit.xml` next to `coverage.out`. It uses `continue-on-error: true` + an explicit `exit $status` so a real test failure **doesn't skip the upload steps** — that's the whole point of Test Analytics (you want failed/flaky test data uploaded *because* tests failed). A final step re-surfaces the failure after upload.
- **Upload coverage** → `codecov-action@v5` (unchanged behavior; tokenless still works for this public repo).
- **Upload test results** → `codecov/test-results-action@v1`, `if: ${{ !cancelled() }}`.

Validated locally: `go test -json | go-junit-report` produces valid JUnit XML (43 testcases from a sample), exit 0 on pass.

## ⚠️ Action required: add the `CODECOV_TOKEN` secret

**Test Analytics requires the token** (unlike coverage, which works tokenless on public repos). Until the `CODECOV_TOKEN` repo secret is set:
- Coverage upload keeps working (tokenless).
- Test-results upload will not authenticate (the step won't fail the build, but no data lands).

To enable: Codecov dashboard → repo settings → copy the upload token → GitHub repo *Settings → Secrets and variables → Actions* → add `CODECOV_TOKEN`. (I can't do this — no org-admin access via `gh`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)