### PR TITLE
ci: use codecov-action@v5 for test results (drop deprecated action)

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -57,10 +57,12 @@ jobs:
 
     - name: Upload test results to Codecov
       if: ${{ !cancelled() }}
-      uses: codecov/test-results-action@v1
+      uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: ./junit.xml
+        report_type: test_results
+        fail_ci_if_error: false
 
     # Surface a genuine test failure now that the results have been uploaded.
     - name: Fail if tests failed


### PR DESCRIPTION
`codecov/test-results-action@v1` emits a deprecation warning in CI:

> This action is being deprecated in favor of 'codecov-action'. Please update CI accordingly to use 'codecov-action@v5' with 'report_type: test_results'.

Switch the test-results upload to the recommended `codecov-action@v5` + `report_type: test_results` (the coverage step already uses v5). Uploads were already working — verified in the run logs (`Found 1 test_results files to report → junit.xml`, `Upload queued for processing complete`) — so this is purely removing the deprecation and future-proofing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)